### PR TITLE
Added meta description

### DIFF
--- a/html/data/learn-items.json
+++ b/html/data/learn-items.json
@@ -15,7 +15,7 @@
 
   {
   "title": "Human Interface Guidelines",
-  "excerpt": "Digial money is new to the human experience. How should designers and app developers create experiences to best on-ramp humanity to such a crucial technology?",
+  "excerpt": "Digital money is new to the human experience. How should designers and app developers create experiences to best on-ramp humanity to such a crucial technology?",
   "href": "human-interface-guidelines.html"
 
   },

--- a/html/includes/defaulthead.html
+++ b/html/includes/defaulthead.html
@@ -10,6 +10,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
+    {{#if description}}
+    <meta name="description" content="{{ description }}">      
+    {{/if}}
 
     <title>{{ title }}</title>
 

--- a/html/pages/develop.html
+++ b/html/pages/develop.html
@@ -5,6 +5,7 @@ H1: Develop on Bitcoin Cash
 subtitle: Change the world
 secondSubtitle: Help bring financial sovereignty to the world
 banner: develop-bitcoin-cash-header.jpg
+description: Develop on Bitcoin Cash and create the next on chain application. Use the BITBOX CLI and learn to develop on Bitcoin Cash. Use our REST layer for Bitcoin.com Cloud. Browse our market place of paid downloads, streaming media, and more.
 ---
 
 {{> develop-header}}

--- a/html/pages/index.html
+++ b/html/pages/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Bitcoin.com Developer Platform | Developer Tooling, Training, Cloud, and Market
+description: Bitcoin.com Developer Platform. Learn to develop on Bitcoin Cash today. Leverage the blockchain to build decentralized and censorship resistant applications. Help bring financial sovereignty to every corner of the world.
 ---
 
 {{> home-header}}

--- a/html/pages/learn.html
+++ b/html/pages/learn.html
@@ -5,6 +5,7 @@ H1: Learn
 subtitle: Get started today!
 banner: learn-bitcoin-cash-header.jpg
 secondSubtitle: Go from hobbyist to professional step-by-step
+description: Learn all about the Bitcoin Cash blockchain with the Bitcoin.com developer program. Read Mastering Bitcoin Cash. Browse Bitcoin Cash tutorials, Bitcoin Cash Insights, and humane interface guidelines
 ---
 
 {{> learn-header}}


### PR DESCRIPTION
Setup conditional meta description to better target keywords for primary pages (index, learn, develop)

Fallback should work fine as google will just pull content from inner pages. But could be helpful for ranking higher on things like "Bitcoin Cash tutorials" etc. 

Also fixed a typo I caught