### PR TITLE
Faucet Fixes

### DIFF
--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -17,6 +17,10 @@ const WrapperDiv = styled.div`
   padding: 50px;
 `
 
+const TxLink = styled.p`
+  padding: 25px;
+`
+
 type Props = {}
 class BchFaucet extends React.PureComponent {
   // constructor to set state and bind "this"
@@ -25,6 +29,8 @@ class BchFaucet extends React.PureComponent {
     this.state = {
       outputText: '',
       bchAddr: '',
+      linkAddr: '#',
+      linkOn: false,
     }
   }
 
@@ -69,6 +75,14 @@ class BchFaucet extends React.PureComponent {
         </button>
 
         <Well>{this.state.outputText}</Well>
+
+        {this.state.linkOn && (
+          <TxLink>
+            <a href={this.state.linkAddr} target="_blank">
+              View TX on Block Explorer
+            </a>
+          </TxLink>
+        )}
 
         <p>
           Please send your leftover testnet coins back to the faucet:
@@ -115,15 +129,25 @@ class BchFaucet extends React.PureComponent {
       }
 
       this.addOutput(`Success: testnet BCH are on their way!`)
-      //this.addOutput(`TXID: ${body.txid}`)
-      this.addOutput(
-        `TXID: <a href="https://www.blocktrail.com/tBCC/tx/${body.txid}">${
-          body.txid
-        }</a>`
-      )
+      this.addOutput(`TXID: ${body.txid}`)
+      //this.addOutput(
+      //  `TXID: <a href="https://www.blocktrail.com/tBCC/tx/${body.txid}">${
+      //    body.txid
+      //  }</a>`
+      //)
+
+      // Show the link to the block explorer.
+      this.showLink(body.txid)
     } catch (err) {
       console.log(`Error in requestBCH: `, err)
     }
+  }
+
+  showLink(txid) {
+    this.setState(prevState => ({
+      linkOn: true,
+      linkAddr: `https://www.blocktrail.com/tBCC/tx/${txid}`,
+    }))
   }
 
   // Add another line to the output.

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -147,11 +147,6 @@ class BchFaucet extends React.PureComponent {
 
       this.addOutput(`Success: testnet BCH are on their way!`)
       this.addOutput(`TXID: ${body.txid}`)
-      //this.addOutput(
-      //  `TXID: <a href="https://www.blocktrail.com/tBCC/tx/${body.txid}">${
-      //    body.txid
-      //  }</a>`
-      //)
 
       // Show the link to the block explorer.
       this.showLink(body.txid)

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -27,15 +27,18 @@ class BchFaucet extends React.PureComponent {
   constructor(props) {
     super(props)
     this.state = {
-      outputText: '',
-      bchAddr: '',
-      linkAddr: '#',
-      linkOn: false,
+      outputText: '', // Output of the Well.
+      bchAddr: '', // bchAddress provided by user.
+      linkAddr: '#', // Link URL to block explorer.
+      linkOn: false, // Toggles block explorer link.
+      balance: 0, // Initial balance before retreiving form server.
     }
   }
 
   render() {
     const {} = this.props
+
+    if (this.state.balance === 0) this.getBalance()
 
     return (
       <WrapperDiv>
@@ -48,8 +51,12 @@ class BchFaucet extends React.PureComponent {
           <a href="https://www.bitcoin.com/bitcoin-mining">
             Bitcoin.com Mining Pool{' '}
           </a>
-          . It currently gives out <u>0.1 BCH</u>.
+          gatsby hide show element state . It currently gives out <u>0.1 BCH</u>
+          .
         </h3>
+
+        <p>Faucet current balance: {this.state.balance} BCH</p>
+
         <p>
           <a href="https://github.com/Bitcoin-com/testnet-faucet">
             Fork the code on GitHub!
@@ -96,6 +103,16 @@ class BchFaucet extends React.PureComponent {
   // Updates the state as the user updates the input form.
   handleChange = ({ target }) => {
     this.setState({ bchAddr: target.value })
+  }
+
+  getBalance = async () => {
+    const resp = await fetch(`${SERVER}/coins/`)
+    const body = await resp.json()
+    //console.log(`body: ${JSON.stringify(body, null, 2)}`)
+
+    this.setState(prevState => ({
+      balance: body.balance,
+    }))
   }
 
   requestBCH = async () => {


### PR DESCRIPTION
Fixes the following in the BCH and WHC testnet faucets:
- There was a bug that was improperly displaying a link to the blockchain explorer of the TXID generated by the faucet. This is now fixed.
- Link to block explorer now appears below the 'well' with a proper link.
- Balance of faucet is displayed on page load, for easy monitoring.