### PR TITLE
Improvement - Faucets using site design

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,18 @@ A bordered box used to render a `tip/info/warning` box.
 
 usage
 
-```html
-// Standard, "Tip" <tip>Use a tip to display tips</tip>
+```
+// Standard, "Tip"
+<tip>Use a tip to display tips</tip>
 
-// Standard, "Tip" with nested
-<i>
-  <tip>Use a tip to display tips <i>in italic</i></tip>
+// Standard, "Tip" with nested <i>
+<tip>Use a tip to display tips <i>in italic</i></tip>
 
-  // Warning <tip nature="warning">Use warnings to display warnings</tip>
+// Warning
+<tip nature="warning">Use warnings to display warnings</tip>
 
-  // Note <tip nature="note">Notes for extra info</tip> ></i
+// Note
+<tip nature="note">Notes for extra info</tip>
 >
 ```
 
@@ -84,13 +86,16 @@ Caption below an image
 
 usage
 
-```html
-// Standard, "Tip" [image text](/images/wow.png)
+```
+// Standard, "Tip"
+[image text](/images/wow.png)
 <image-caption>Use a tip to display tips</image-caption>
 
-// Warning <tip nature="warning">Use warnings to display warnings</tip>
+// Warning
+<tip nature="warning">Use warnings to display warnings</tip>
 
-// Note <tip nature="note">Notes for extra info</tip>
+// Note
+<tip nature="note">Notes for extra info</tip>
 ```
 
 ##### anchor
@@ -99,8 +104,9 @@ Anchor to link to if the auto-generated header anchors aren't working
 
 usage
 
-```html
-// basic invisible anchor <anchor name="link-to-me"></anchor>
+```
+// basic invisible anchor
+<anchor name="link-to-me"></anchor>
 ```
 
 ##### spacer
@@ -109,8 +115,9 @@ Empty space until we can figure out a better solution
 
 usage
 
-```html
-// some extra spce <spacer></spacer>
+```
+// some extra spce
+<spacer></spacer>
 ```
 
 #### Deploy

--- a/README.md
+++ b/README.md
@@ -68,14 +68,13 @@ usage
 ```html
 // Standard, "Tip" <tip>Use a tip to display tips</tip>
 
-// Standard, "Tip", need to use
+// Standard, "Tip" with nested
 <i>
-  explicitly rather than the mardown _version_
   <tip>Use a tip to display tips <i>in italic</i></tip>
 
   // Warning <tip nature="warning">Use warnings to display warnings</tip>
 
-  // Note <tip nature="note">Notes for extra info</tip></i
+  // Note <tip nature="note">Notes for extra info</tip> ></i
 >
 ```
 

--- a/src/atoms/Input.js
+++ b/src/atoms/Input.js
@@ -8,12 +8,11 @@ const Input = styled.input`
   color: ${props => props.theme.foreground};
   border: 2px solid ${props => props.theme.backgroundMuted};
   outline: none;
-  padding-top: 15px;
-  padding-right: 15px;
-  padding-bottom: 15px;
-  padding-left: 25px;
-  border-radius: 35px;
-  width: ${props => (props.fit ? 'fit-content' : 'auto')};
+  padding-top: 7px;
+  padding-right: 7px;
+  padding-bottom: 7px;
+  padding-left: 7px;
+  border-radius: 7px;
   ::placeholder {
     color: ${props => props.theme.backgroundMuted};
   }

--- a/src/atoms/Pre.js
+++ b/src/atoms/Pre.js
@@ -3,7 +3,6 @@
 import styled from 'styled-components'
 import { defaultProps } from 'recompose'
 
-import spacing from 'styles/spacing'
 import { textBase } from 'atoms/Text'
 
 const Pre = defaultProps({ monospace: true })(styled.span`

--- a/src/atoms/StyledLink.js
+++ b/src/atoms/StyledLink.js
@@ -16,7 +16,6 @@ const StyledLink = styled(Link)`
     color: ${props => props.theme.secondary};
   }
 `
-
 const StyledA = props => <StyledLink as="a" {...props} />
 
 type Props = {

--- a/src/atoms/Well.js
+++ b/src/atoms/Well.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+
+const Well = styled.div`
+  background-color: ${props => props.theme.primary100};
+  min-height: 20px;
+  padding: 20px;
+  margin-bottom: 20px;
+  border: 1px solid ${props => props.theme.primary200};
+  border-radius: 4px;
+  white-space: pre-line;
+`
+
+export default Well

--- a/src/atoms/Well.js
+++ b/src/atoms/Well.js
@@ -1,6 +1,5 @@
 // @flow
 
-import React from 'react'
 import styled from 'styled-components'
 
 const Well = styled.div`

--- a/src/atoms/headerBase.js
+++ b/src/atoms/headerBase.js
@@ -1,8 +1,4 @@
 // @flow
-
-import Text from './Text'
-
-// @flow
 import styled from 'styled-components'
 
 import { textBase } from './Text'

--- a/src/components/FaucetBalanceDisplay.js
+++ b/src/components/FaucetBalanceDisplay.js
@@ -1,0 +1,48 @@
+// @flow
+import React from 'react'
+import styled from 'styled-components'
+
+import spacing from 'styles/spacing'
+import Text from 'atoms/Text'
+
+const BalanceGrid = styled.div`
+  display: grid;
+  grid-template-rows: auto auto;
+  grid-template-columns: max-content;
+`
+
+const BalanceRow = styled.div`
+  display: grid;
+  grid-auto-flow: column;
+  grid-gap: ${spacing.large};
+  justify-content: space-between;
+  background-color: ${props => props.theme.primary100};
+`
+type Props = {
+  title: string,
+  data: {
+    item: string,
+    amount: number | string,
+  }[],
+}
+const BalanceDisplay = (props: Props) => {
+  const { title, data } = props
+  console.log(data)
+  return (
+    <BalanceGrid>
+      <Text bold center>
+        {title}
+      </Text>
+      <BalanceRow>
+        {data.map(val => (
+          <div>
+            <Text center>{val.item}</Text>
+            <Text center>{Number(val.amount).toFixed(8)}</Text>
+          </div>
+        ))}
+      </BalanceRow>
+    </BalanceGrid>
+  )
+}
+
+export default BalanceDisplay

--- a/src/components/FaucetBalanceDisplay.js
+++ b/src/components/FaucetBalanceDisplay.js
@@ -9,14 +9,15 @@ const BalanceGrid = styled.div`
   display: grid;
   grid-template-rows: auto auto;
   grid-template-columns: max-content;
+  align-content: center;
 `
 
 const BalanceRow = styled.div`
   display: grid;
   grid-auto-flow: column;
   grid-gap: ${spacing.large};
-  justify-content: space-between;
   background-color: ${props => props.theme.primary100};
+  padding: 10px;
 `
 type Props = {
   title: string,
@@ -35,7 +36,13 @@ const BalanceDisplay = (props: Props) => {
       </Text>
       <BalanceRow>
         {data.map(val => (
-          <div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}
+          >
             <Text center>{val.item}</Text>
             <Text center>{Number(val.amount).toFixed(8)}</Text>
           </div>

--- a/src/components/InfoCard.js
+++ b/src/components/InfoCard.js
@@ -3,7 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { FaAngleRight } from 'react-icons/fa'
 
-import StyledLink from 'atoms/StyledLink'
+import StyledLink, { SmartLink } from 'atoms/StyledLink'
 import H3 from 'atoms/H3'
 import Text from 'atoms/Text'
 import Button from 'atoms/Button'
@@ -15,8 +15,8 @@ const Main = styled.div`
   grid-template-columns: 1fr;
   grid-template-rows: min-content 1fr min-content;
   grid-gap: ${spacing.small};
-  border-bottom: 1px solid ${props => props.theme.primary};
-  border-top: 1px solid ${props => props.theme.primary};
+  border: 1px solid ${props => props.theme.primary200};
+  box-shadow: 2px 1px 1px ${props => props.theme.primary100};
   padding: ${spacing.small};
   border-radius: 8px;
 `
@@ -27,7 +27,7 @@ const Right = styled.div`
 type Props = {
   title: string,
   text: string,
-  to?: string,
+  to: string,
   cta?: string,
   disabledcta?: string,
 }
@@ -36,7 +36,9 @@ class InfoCard extends React.PureComponent<Props> {
     const { title, text, to, cta, disabledcta } = this.props
     return (
       <Main>
-        <H3>{title}</H3>
+        <SmartLink to={to} subtle>
+          <H3>{title}</H3>
+        </SmartLink>
         <Text muted>{text}</Text>
         <Right>
           {cta && (

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -45,6 +45,7 @@ const developBaseUrls = [
   '/gui',
   '/rest',
   '/slp',
+  '/faucets',
 ]
 const learnBaseUrls = [
   '/learn',

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -38,7 +38,14 @@ type Props = {
 }
 
 // TODO: Better method of this to not have false positives like /tutorials/wormhole-3 triggering 2 tabs active
-const developBaseUrls = ['/develop', '/bitbox', '/wormhole', '/gui', '/rest']
+const developBaseUrls = [
+  '/develop',
+  '/bitbox',
+  '/wormhole',
+  '/gui',
+  '/rest',
+  '/slp',
+]
 const learnBaseUrls = [
   '/learn',
   '/tutorials',

--- a/src/components/ShareFooter.js
+++ b/src/components/ShareFooter.js
@@ -70,7 +70,6 @@ const makeShareLink = (
 class ShareFooter extends React.Component<Props> {
   componentDidMount() {
     const om = document.createElement('script')
-    const date = new Date()
     om.src = `https://a.optmnstr.com/app/js/api.min.js`
     om.setAttribute('data-campaign', 'v8lwzo6nqacmgnulutqp')
     om.setAttribute('data-user', '46652')

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -17,7 +17,7 @@ import FaucetBalanceDisplay from './FaucetBalanceDisplay'
 const SERVER = `https://faucet.christroutner.com`
 
 const WrapperDiv = styled.div`
-  padding: 50px;
+  padding-top: ${spacing.large};
   display: grid;
   grid-gap: ${spacing.small};
 `

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -4,37 +4,52 @@ import 'isomorphic-fetch'
 import React from 'react'
 import styled from 'styled-components'
 
-const SERVER = `https://faucet.christroutner.com`
+import Button from 'atoms/Button'
+import StyledLink, { SmartLink } from 'atoms/StyledLink'
+import H3 from 'atoms/H3'
+import Text from 'atoms/Text'
+import Input from 'atoms/Input'
+import Well from 'atoms/Well'
+import spacing from 'styles/spacing'
 
-const Well = styled.p`
-  background-color: #f5f5f5;
-  min-height: 20px;
-  padding: 20px;
-  margin-bottom: 20px;
-  border: 1px solid #e3e3e3;
-  border-radius: 4px;
-  white-space: pre-line;
-`
+import FaucetBalanceDisplay from './FaucetBalanceDisplay'
+
+const SERVER = `https://faucet.christroutner.com`
 
 const WrapperDiv = styled.div`
   padding: 50px;
+  display: grid;
+  grid-gap: ${spacing.small};
 `
 
 const TxLink = styled.p`
   padding: 25px;
 `
 
+const AddressForm = styled.form`
+  display: grid;
+  grid-gap: ${spacing.small};
+  grid-auto-columns: min-content;
+`
+
 type Props = {}
-class BchFaucet extends React.PureComponent {
-  // constructor to set state and bind "this"
-  constructor(props) {
+type State = {
+  outputText: string, // Output of the Well.
+  bchAddr: string, // bchAddress provided by user.
+  linkAddr: string, // Link URL to block explorer.
+  linkOn: boolean, // Toggles block explorer link.
+  balance: number, // Initial balance before retreiving form server.
+}
+
+class BchFaucet extends React.PureComponent<Props, State> {
+  constructor(props: Props) {
     super(props)
     this.state = {
-      outputText: '', // Output of the Well.
-      bchAddr: '', // bchAddress provided by user.
-      linkAddr: '#', // Link URL to block explorer.
-      linkOn: false, // Toggles block explorer link.
-      balance: 0, // Initial balance before retreiving form server.
+      outputText: '',
+      bchAddr: '',
+      linkAddr: '#',
+      linkOn: false,
+      balance: 0,
     }
   }
 
@@ -45,60 +60,61 @@ class BchFaucet extends React.PureComponent {
 
     return (
       <WrapperDiv>
-        <h3>
+        <H3>
           This is a <u>testnet</u> faucet for Bitcoin Cash! It is built with{' '}
-          <a href="https://developer.bitcoin.com/bitbox">
-            BITBOX JavaScript SDK
-          </a>{' '}
+          <StyledLink to="/bitbox">BITBOX JavaScript SDK</StyledLink>
           and is funded by the{' '}
-          <a href="https://www.bitcoin.com/bitcoin-mining">
-            Bitcoin.com Mining Pool{' '}
-          </a>
-          gatsby hide show element state . It currently gives out <u>0.1 BCH</u>
-          .
-        </h3>
+          <SmartLink to="https://www.bitcoin.com/bitcoin-mining">
+            Bitcoin.com Mining Pool
+          </SmartLink>
+          . It currently gives out <u>0.1 BCH</u>.
+        </H3>
 
-        <p>Faucet current balance: {this.state.balance} BCH</p>
+        <FaucetBalanceDisplay
+          title="Current faucet balance"
+          data={[{ item: 'BCH', amount: this.state.balance }]}
+        />
 
-        <p>
-          <a href="https://github.com/Bitcoin-com/testnet-faucet">
+        <Text>
+          <SmartLink to="https://github.com/Bitcoin-com/testnet-faucet">
             Fork the code on GitHub!
-          </a>
-        </p>
+          </SmartLink>
+        </Text>
 
-        <form>
-          <div>
-            <label for="bchAddr">BCH Testnet Address: </label>
-            <input
-              type="text"
-              id="bchAddr"
-              size="45"
-              placeholder="bchtest:qqmd9unmhkpx4pkmr6fkrr8rm6y77vckjvqe8aey35"
-              value={this.state.bchAddr}
-              onChange={this.handleChange}
-            />
-          </div>
-        </form>
+        <AddressForm>
+          <Text for="bchAddr" as="label" bold>
+            BCH Testnet Address
+          </Text>
+          <Input
+            type="text"
+            id="bchAddr"
+            size="45"
+            placeholder="bchtest:qqmd9unmhkpx4pkmr6fkrr8rm6y77vckjvqe8aey35"
+            value={this.state.bchAddr}
+            onChange={this.handleChange}
+          />
+          <Button type="button" onClick={this.requestBCH}>
+            Get tBCH!
+          </Button>
+        </AddressForm>
 
-        <button type="button" onClick={this.requestBCH}>
-          Get tBCH!
-        </button>
-
-        <Well>{this.state.outputText}</Well>
+        <Well>
+          <Text>{this.state.outputText}</Text>
+        </Well>
 
         {this.state.linkOn && (
           <TxLink>
-            <a href={this.state.linkAddr} target="_blank">
+            <SmartLink to={this.state.linkAddr}>
               View TX on Block Explorer
-            </a>
+            </SmartLink>
           </TxLink>
         )}
 
-        <p>
+        <Text>
           Please send your leftover testnet coins back to the faucet:
           <br />
           <i>bchtest:qqmd9unmhkpx4pkmr6fkrr8rm6y77vckjvqe8aey35</i>
-        </p>
+        </Text>
       </WrapperDiv>
     )
   }
@@ -111,7 +127,6 @@ class BchFaucet extends React.PureComponent {
   getBalance = async () => {
     const resp = await fetch(`${SERVER}/coins/`)
     const body = await resp.json()
-    //console.log(`body: ${JSON.stringify(body, null, 2)}`)
 
     this.setState(prevState => ({
       balance: body.balance,
@@ -120,8 +135,6 @@ class BchFaucet extends React.PureComponent {
 
   requestBCH = async () => {
     try {
-      //console.log(`state.bchAddr: ${this.state.bchAddr}`)
-
       this.wipeOutput()
 
       this.addOutput(`Sending request...`)

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -88,7 +88,7 @@ class BchFaucet extends React.PureComponent<Props, State> {
           <Input
             type="text"
             id="bchAddr"
-            size="45"
+            size="60"
             placeholder="bchtest:qqmd9unmhkpx4pkmr6fkrr8rm6y77vckjvqe8aey35"
             value={this.state.bchAddr}
             onChange={this.handleChange}

--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -54,8 +54,6 @@ class BchFaucet extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {} = this.props
-
     if (this.state.balance === 0) this.getBalance()
 
     return (

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -17,7 +17,7 @@ import FaucetBalanceDisplay from './FaucetBalanceDisplay'
 const SERVER = `https://faucet.christroutner.com`
 
 const WrapperDiv = styled.div`
-  padding: 50px;
+  padding-top: ${spacing.large};
   display: grid;
   grid-gap: ${spacing.small};
 `

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -56,8 +56,6 @@ class BchFaucet extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {} = this.props
-
     if (this.state.whcBalance === 0) this.getBalance()
 
     return (

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -93,7 +93,7 @@ class BchFaucet extends React.PureComponent<Props, State> {
           <Input
             type="text"
             id="bchAddr"
-            size="45"
+            size="60"
             placeholder="bchtest:qr8d0cp00a07gwf7ltg4ufu48a849j98x5dj7zk423"
             value={this.state.bchAddr}
             onChange={this.handleChange}

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -7,25 +7,38 @@ import styled from 'styled-components'
 import Button from 'atoms/Button'
 import StyledLink, { SmartLink } from 'atoms/StyledLink'
 import H3 from 'atoms/H3'
+import Text from 'atoms/Text'
+import Input from 'atoms/Input'
+import spacing from 'styles/spacing'
+
+import FaucetBalanceDisplay from './FaucetBalanceDisplay'
 
 const SERVER = `https://faucet.christroutner.com`
 
 const Well = styled.p`
-  background-color: #f5f5f5;
+  background-color: ${props => props.theme.primary100};
   min-height: 20px;
   padding: 20px;
   margin-bottom: 20px;
-  border: 1px solid #e3e3e3;
+  border: 1px solid ${props => props.theme.primary200};
   border-radius: 4px;
   white-space: pre-line;
 `
 
 const WrapperDiv = styled.div`
   padding: 50px;
+  display: grid;
+  grid-gap: ${spacing.small};
 `
 
 const TxLink = styled.p`
   padding: 25px;
+`
+
+const AddressForm = styled.form`
+  display: grid;
+  grid-gap: ${spacing.small};
+  grid-auto-columns: min-content;
 `
 
 type Props = {}
@@ -37,8 +50,8 @@ type State = {
   bchBalance: number, // Initial balance before retreiving form server.
   whcBalance: number,
 }
+
 class BchFaucet extends React.PureComponent<Props, State> {
-  // constructor to set state and bind "this"
   constructor(props: Props) {
     super(props)
     this.state = {
@@ -63,55 +76,57 @@ class BchFaucet extends React.PureComponent<Props, State> {
           <StyledLink to="/bitbox">BITBOX JavaScript SDK</StyledLink>
           and is funded by the{' '}
           <SmartLink to="https://www.bitcoin.com/bitcoin-mining">
-            Bitcoin.com Mining Pool{' '}
+            Bitcoin.com Mining Pool
           </SmartLink>
           . It currently gives out <u>3 WHC</u>.
         </H3>
 
-        <p>
-          Current faucet balance: {this.state.bchBalance} BCH,{' '}
-          {this.state.whcBalance} WHC
-        </p>
+        <FaucetBalanceDisplay
+          title="Current faucet balance"
+          data={[
+            { item: 'BCH', amount: this.state.bchBalance },
+            { item: 'WHC', amount: this.state.whcBalance },
+          ]}
+        />
 
-        <p>
-          <a href="https://github.com/Bitcoin-com/whc-faucet">
+        <Text>
+          <SmartLink to="https://github.com/Bitcoin-com/whc-faucet">
             Fork the code on GitHub!
-          </a>
-        </p>
+          </SmartLink>
+        </Text>
 
-        <form>
-          <div>
-            <label for="bchAddr">BCH Testnet Address: </label>
-            <input
-              type="text"
-              id="bchAddr"
-              size="45"
-              placeholder="bchtest:qr8d0cp00a07gwf7ltg4ufu48a849j98x5dj7zk423"
-              value={this.state.bchAddr}
-              onChange={this.handleChange}
-            />
-          </div>
-        </form>
-
-        <Button type="button" onClick={this.requestWHC}>
-          Get tBCH!
-        </Button>
+        <AddressForm>
+          <Text for="bchAddr" as="label" bold>
+            BCH Testnet Address
+          </Text>
+          <Input
+            type="text"
+            id="bchAddr"
+            size="45"
+            placeholder="bchtest:qr8d0cp00a07gwf7ltg4ufu48a849j98x5dj7zk423"
+            value={this.state.bchAddr}
+            onChange={this.handleChange}
+          />
+          <Button type="button" onClick={this.requestWHC}>
+            Get tBCH!
+          </Button>
+        </AddressForm>
 
         <Well>{this.state.outputText}</Well>
 
         {this.state.linkOn && (
           <TxLink>
-            <a href={this.state.linkAddr} target="_blank">
+            <SmartLink to={this.state.linkAddr}>
               View TX on Block Explorer
-            </a>
+            </SmartLink>
           </TxLink>
         )}
 
-        <p>
+        <Text>
           Please send your leftover testnet coins back to the faucet:
           <br />
           <i>bchtest:qr8d0cp00a07gwf7ltg4ufu48a849j98x5dj7zk423</i>
-        </p>
+        </Text>
       </WrapperDiv>
     )
   }
@@ -125,7 +140,6 @@ class BchFaucet extends React.PureComponent<Props, State> {
   getBalance = async () => {
     const resp = await fetch(`${SERVER}/tokens/`)
     const body = await resp.json()
-    //console.log(`body: ${JSON.stringify(body, null, 2)}`)
 
     this.setState(prevState => ({
       bchBalance: body.bch,
@@ -135,10 +149,7 @@ class BchFaucet extends React.PureComponent<Props, State> {
 
   requestWHC = async () => {
     try {
-      //console.log(`state.bchAddr: ${this.state.bchAddr}`)
-
       this.wipeOutput()
-
       this.addOutput(`Sending request...`)
 
       if (this.state.bchAddr === '') {
@@ -148,7 +159,6 @@ class BchFaucet extends React.PureComponent<Props, State> {
 
       const resp = await fetch(`${SERVER}/tokens/${this.state.bchAddr}`)
       const body = await resp.json()
-      console.log(`body: ${JSON.stringify(body, null, 2)}`)
 
       if (!body.success) {
         const message = body.message

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -9,21 +9,12 @@ import StyledLink, { SmartLink } from 'atoms/StyledLink'
 import H3 from 'atoms/H3'
 import Text from 'atoms/Text'
 import Input from 'atoms/Input'
+import Well from 'atoms/Well'
 import spacing from 'styles/spacing'
 
 import FaucetBalanceDisplay from './FaucetBalanceDisplay'
 
 const SERVER = `https://faucet.christroutner.com`
-
-const Well = styled.p`
-  background-color: ${props => props.theme.primary100};
-  min-height: 20px;
-  padding: 20px;
-  margin-bottom: 20px;
-  border: 1px solid ${props => props.theme.primary200};
-  border-radius: 4px;
-  white-space: pre-line;
-`
 
 const WrapperDiv = styled.div`
   padding: 50px;
@@ -48,7 +39,7 @@ type State = {
   linkAddr: string, // Link URL to block explorer.
   linkOn: boolean, // Toggles block explorer link.
   bchBalance: number, // Initial balance before retreiving form server.
-  whcBalance: number,
+  whcBalance: string, // Coming back as string from API.  Works, but should turn to number
 }
 
 class BchFaucet extends React.PureComponent<Props, State> {
@@ -112,7 +103,9 @@ class BchFaucet extends React.PureComponent<Props, State> {
           </Button>
         </AddressForm>
 
-        <Well>{this.state.outputText}</Well>
+        <Well>
+          <Text>{this.state.outputText}</Text>
+        </Well>
 
         {this.state.linkOn && (
           <TxLink>
@@ -191,7 +184,7 @@ class BchFaucet extends React.PureComponent<Props, State> {
   }
 
   // Add another line to the output.
-  addOutput = str => {
+  addOutput = (str: string) => {
     this.setState(prevState => ({
       outputText: prevState.outputText + `\n${str}`,
     }))

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -1,5 +1,11 @@
+// @flow
+
 import React from 'react'
 import styled from 'styled-components'
+
+import Button from 'atoms/Button'
+import StyledLink, { SmartLink } from 'atoms/StyledLink'
+import H3 from 'atoms/H3'
 
 const SERVER = `https://faucet.christroutner.com`
 
@@ -22,17 +28,25 @@ const TxLink = styled.p`
 `
 
 type Props = {}
-class BchFaucet extends React.PureComponent {
+type State = {
+  outputText: string, // Output of the Well.
+  bchAddr: string, // bchAddress provided by user.
+  linkAddr: string, // Link URL to block explorer.
+  linkOn: boolean, // Toggles block explorer link.
+  bchBalance: number, // Initial balance before retreiving form server.
+  whcBalance: number,
+}
+class BchFaucet extends React.PureComponent<Props, State> {
   // constructor to set state and bind "this"
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
     this.state = {
-      outputText: '', // Output of the Well.
-      bchAddr: '', // bchAddress provided by user.
-      linkAddr: '#', // Link URL to block explorer.
-      linkOn: false, // Toggles block explorer link.
-      bchBalance: 0, // Initial balance before retreiving form server.
-      whcBalance: 0, // Initial balance before retreiving from the server.
+      outputText: '',
+      bchAddr: '',
+      linkAddr: '#',
+      linkOn: false,
+      bchBalance: 0,
+      whcBalance: 0,
     }
   }
 
@@ -43,17 +57,15 @@ class BchFaucet extends React.PureComponent {
 
     return (
       <WrapperDiv>
-        <h3>
+        <H3>
           This is a <u>testnet</u> faucet Wormhole coins! It is built with{' '}
-          <a href="https://developer.bitcoin.com/bitbox">
-            BITBOX JavaScript SDK
-          </a>{' '}
+          <StyledLink to="/bitbox">BITBOX JavaScript SDK</StyledLink>
           and is funded by the{' '}
-          <a href="https://www.bitcoin.com/bitcoin-mining">
+          <SmartLink to="https://www.bitcoin.com/bitcoin-mining">
             Bitcoin.com Mining Pool{' '}
-          </a>
+          </SmartLink>
           . It currently gives out <u>3 WHC</u>.
-        </h3>
+        </H3>
 
         <p>
           Current faucet balance: {this.state.bchBalance} BCH,{' '}
@@ -80,9 +92,9 @@ class BchFaucet extends React.PureComponent {
           </div>
         </form>
 
-        <button type="button" onClick={this.requestWHC}>
+        <Button type="button" onClick={this.requestWHC}>
           Get tBCH!
-        </button>
+        </Button>
 
         <Well>{this.state.outputText}</Well>
 

--- a/src/pages/faucets.js
+++ b/src/pages/faucets.js
@@ -7,6 +7,7 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
+import InfoCard from 'components/InfoCard'
 
 import { FaAngleRight } from 'react-icons/fa'
 
@@ -28,6 +29,7 @@ const HeroLayout = styled.div`
 const SectionLayout = styled.div`
   display: grid;
   padding-top: ${spacing.large};
+  padding-bottom: ${spacing.large};
   grid-gap: ${spacing.medium};
   grid-template-columns: 1fr;
   ${media.medium`
@@ -74,33 +76,18 @@ const Faucet = ({ location }: Props) => (
     </Hero>
     <Container>
       <SectionLayout>
-        <SectionItem>
-          <StyledLink to="/faucets/bch" subtle>
-            <H3>BCH</H3>
-          </StyledLink>
-          <Text>Bitcoin Cash testnet faucet</Text>
-          <CTASection>
-            <StyledLink to="/faucets/bch">
-              <Text centerVertical bold>
-                View <FaAngleRight />
-              </Text>
-            </StyledLink>
-          </CTASection>
-        </SectionItem>
-        <SectionItem>
-          <StyledLink to="/faucets/whc" subtle>
-            <H3>WHC</H3>
-          </StyledLink>
-          <Text>Wormhole testnet faucet</Text>
-
-          <CTASection>
-            <StyledLink to="/faucets/whc">
-              <Text centerVertical bold>
-                View <FaAngleRight />
-              </Text>
-            </StyledLink>
-          </CTASection>
-        </SectionItem>
+        <InfoCard
+          to="/faucets/bch"
+          title="BCH Testnet Faucet"
+          text="Bitcoin Cash testnet faucet.  Get some testnet BCH for your development needs"
+          cta="View"
+        />
+        <InfoCard
+          to="/faucets/whc"
+          title="WHC Testnet Faucet"
+          text="Wormhole testnet faucet.  Get some testnet BCH for your development needs"
+          cta="View"
+        />
       </SectionLayout>
     </Container>
   </DefaultLayout>

--- a/src/pages/faucets.js
+++ b/src/pages/faucets.js
@@ -27,7 +27,7 @@ const HeroLayout = styled.div`
 
 const SectionLayout = styled.div`
   display: grid;
-  padding-top: ${spacing.medium};
+  padding-top: ${spacing.large};
   grid-gap: ${spacing.medium};
   grid-template-columns: 1fr;
   ${media.medium`
@@ -43,12 +43,13 @@ const SectionItem = styled.div`
   grid-template-rows: max-content 1fr max-content;
   grid-column: ${props => (props.full ? 'span 2' : 'auto')};
   border-left: 2px solid ${props => props.theme.primary};
+  /* border: 1px solid ${props => props.theme.primary100}; */
   padding-left: ${spacing.tiny};
 `
 
 const CTASection = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
 `
 
 type Props = {
@@ -74,7 +75,9 @@ const Faucet = ({ location }: Props) => (
     <Container>
       <SectionLayout>
         <SectionItem>
-          <H3>BCH</H3>
+          <StyledLink to="/faucets/bch" subtle>
+            <H3>BCH</H3>
+          </StyledLink>
           <Text>Bitcoin Cash testnet faucet</Text>
           <CTASection>
             <StyledLink to="/faucets/bch">
@@ -85,7 +88,9 @@ const Faucet = ({ location }: Props) => (
           </CTASection>
         </SectionItem>
         <SectionItem>
-          <H3>WHC</H3>
+          <StyledLink to="/faucets/whc" subtle>
+            <H3>WHC</H3>
+          </StyledLink>
           <Text>Wormhole testnet faucet</Text>
 
           <CTASection>

--- a/src/pages/faucets.js
+++ b/src/pages/faucets.js
@@ -9,12 +9,8 @@ import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
 import InfoCard from 'components/InfoCard'
 
-import { FaAngleRight } from 'react-icons/fa'
-
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
-import StyledLink from 'atoms/StyledLink'
 
 import media from 'styles/media'
 import spacing from 'styles/spacing'
@@ -35,23 +31,6 @@ const SectionLayout = styled.div`
   ${media.medium`
     grid-template-columns: repeat(auto-fit, minmax(400px, .5fr));
   `};
-`
-
-// const PreviewItem = styled.div`
-const SectionItem = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-  grid-auto-rows: min-content;
-  grid-template-rows: max-content 1fr max-content;
-  grid-column: ${props => (props.full ? 'span 2' : 'auto')};
-  border-left: 2px solid ${props => props.theme.primary};
-  /* border: 1px solid ${props => props.theme.primary100}; */
-  padding-left: ${spacing.tiny};
-`
-
-const CTASection = styled.div`
-  display: flex;
-  justify-content: flex-start;
 `
 
 type Props = {

--- a/src/pages/faucets/bch.js
+++ b/src/pages/faucets/bch.js
@@ -8,14 +8,9 @@ import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
 
-import { FaAngleRight } from 'react-icons/fa'
-
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
-import StyledLink from 'atoms/StyledLink'
 
-import media from 'styles/media'
 import spacing from 'styles/spacing'
 
 import HeroImg from 'images/learn-bitcoin-cash-header.jpg'
@@ -25,32 +20,6 @@ import BchFaucet from 'components/bch-faucet'
 const HeroLayout = styled.div`
   display: grid;
   grid-gap: ${spacing.tiny};
-`
-
-const SectionLayout = styled.div`
-  display: grid;
-  padding-top: ${spacing.medium};
-  grid-gap: ${spacing.medium};
-  grid-template-columns: 1fr;
-  ${media.medium`
-    grid-template-columns: repeat(auto-fit, minmax(400px, .5fr));
-  `};
-`
-
-// const PreviewItem = styled.div`
-const SectionItem = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-  grid-auto-rows: min-content;
-  grid-template-rows: max-content 1fr max-content;
-  grid-column: ${props => (props.full ? 'span 2' : 'auto')};
-  border-left: 2px solid ${props => props.theme.primary};
-  padding-left: ${spacing.tiny};
-`
-
-const CTASection = styled.div`
-  display: flex;
-  justify-content: flex-end;
 `
 
 type Props = {

--- a/src/pages/faucets/whc.js
+++ b/src/pages/faucets/whc.js
@@ -7,50 +7,18 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
+import WhcFaucet from 'components/whc-faucet'
 
-import { FaAngleRight } from 'react-icons/fa'
-
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
-import StyledLink from 'atoms/StyledLink'
 
-import media from 'styles/media'
 import spacing from 'styles/spacing'
 
 import HeroImg from 'images/learn-bitcoin-cash-header.jpg'
 
-import WhcFaucet from 'components/whc-faucet'
-
 const HeroLayout = styled.div`
   display: grid;
   grid-gap: ${spacing.tiny};
-`
-
-const SectionLayout = styled.div`
-  display: grid;
-  padding-top: ${spacing.medium};
-  grid-gap: ${spacing.medium};
-  grid-template-columns: 1fr;
-  ${media.medium`
-    grid-template-columns: repeat(auto-fit, minmax(400px, .5fr));
-  `};
-`
-
-// const PreviewItem = styled.div`
-const SectionItem = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-  grid-auto-rows: min-content;
-  grid-template-rows: max-content 1fr max-content;
-  grid-column: ${props => (props.full ? 'span 2' : 'auto')};
-  border-left: 2px solid ${props => props.theme.primary};
-  padding-left: ${spacing.tiny};
-`
-
-const CTASection = styled.div`
-  display: flex;
-  justify-content: flex-end;
 `
 
 type Props = {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -42,8 +42,9 @@ const HeroBlurbLayout = styled.div`
 
 const HeroButtonLayout = styled.div`
   display: grid;
-  grid-gap: ${spacing.medium};
-  grid-template-columns: auto 1fr;
+  grid-gap: ${spacing.small};
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
 `
 const SDKLayout = styled.div`
   display: grid;

--- a/src/pages/insights.js
+++ b/src/pages/insights.js
@@ -10,9 +10,8 @@ import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
 import InfoCard from 'components/InfoCard'
 
-import { FaAngleRight, FaAngleLeft } from 'react-icons/fa'
+import { FaAngleLeft } from 'react-icons/fa'
 
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
 import StyledLink from 'atoms/StyledLink'

--- a/src/pages/insights.js
+++ b/src/pages/insights.js
@@ -8,6 +8,7 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
+import InfoCard from 'components/InfoCard'
 
 import { FaAngleRight, FaAngleLeft } from 'react-icons/fa'
 
@@ -17,6 +18,7 @@ import H1 from 'atoms/H1'
 import StyledLink from 'atoms/StyledLink'
 
 import spacing from 'styles/spacing'
+import media from 'styles/media'
 
 import HeroImg from 'images/learn-bitcoin-cash-header.jpg'
 
@@ -26,16 +28,14 @@ const HeroLayout = styled.div`
 `
 
 const PreviewLayout = styled.div`
-  margin-top: ${spacing.medium};
   display: grid;
+  padding-top: ${spacing.large};
   grid-gap: ${spacing.medium};
+  grid-template-columns: 1fr;
+  ${media.medium`
+    grid-template-columns: repeat(auto-fit, minmax(400px, .5fr));
+  `};
 `
-
-const PostPreviewLayout = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-`
-const PostHeaderLayout = styled.div``
 
 type Props = {
   location: Object,
@@ -87,19 +87,12 @@ const Insights = ({ location, data }: Props) => {
       <Container>
         <PreviewLayout>
           {posts.map(post => (
-            <PostPreviewLayout>
-              <PostHeaderLayout>
-                <StyledLink subtle to={post.node.fields.slug}>
-                  <H3>{post.node.frontmatter.title} </H3>
-                </StyledLink>
-              </PostHeaderLayout>
-              <Text>{post.node.frontmatter.description}</Text>
-              <StyledLink to={post.node.fields.slug}>
-                <Text centerVertical bold>
-                  Read more <FaAngleRight />
-                </Text>
-              </StyledLink>
-            </PostPreviewLayout>
+            <InfoCard
+              to={post.node.fields.slug}
+              title={post.node.frontmatter.title}
+              text={post.node.frontmatter.description}
+              cta="Read More"
+            />
           ))}
         </PreviewLayout>
       </Container>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -8,6 +8,8 @@ import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
 
+import InfoCard from 'components/InfoCard'
+
 import { FaAngleRight } from 'react-icons/fa'
 
 import Text from 'atoms/Text'
@@ -35,22 +37,6 @@ const SectionLayout = styled.div`
   `};
 `
 
-// const PreviewItem = styled.div`
-const SectionItem = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-  grid-auto-rows: min-content;
-  grid-template-rows: max-content 1fr max-content;
-  grid-column: ${props => (props.full ? 'span 2' : 'auto')};
-  border-left: 2px solid ${props => props.theme.primary};
-  padding-left: ${spacing.tiny};
-`
-
-const CTASection = styled.div`
-  display: flex;
-  justify-content: flex-end;
-`
-
 type Props = {
   location: Object,
 }
@@ -75,51 +61,29 @@ const Learn = ({ location }: Props) => (
     </Hero>
     <Container>
       <SectionLayout>
-        <SectionItem>
-          <H3>Tutorials</H3>
-          <Text>
-            Step by step instructions to build Bitcoin Cash apps from scratch.
+        <InfoCard
+          to="/tutorials"
+          title="Tutorials"
+          text="Step by step instructions to build Bitcoin Cash apps from scratch.
             See real world examples get built and have your own working copies
-            to bootstrap your project from.
-          </Text>
-          <CTASection>
-            <StyledLink to="/tutorials">
-              <Text centerVertical bold>
-                View <FaAngleRight />
-              </Text>
-            </StyledLink>
-          </CTASection>
-        </SectionItem>
-        <SectionItem>
-          <H3>Insights</H3>
-          <Text>
-            Learn from developers who have already shipped successful apps. What
-            worked and what would they do different?
-          </Text>
-
-          <CTASection>
-            <StyledLink to="/insights">
-              <Text centerVertical bold>
-                View <FaAngleRight />
-              </Text>
-            </StyledLink>
-          </CTASection>
-        </SectionItem>
-        <SectionItem>
-          <H3>Mastering Bitcoin Cash</H3>
-          <Text>
-            Based on Mastering Bitcoin by Andreas M. Antonopoulos, Mastering
+            to bootstrap your project from."
+          cta="View"
+        />
+        <InfoCard
+          to="/insights"
+          title="Insights"
+          text="Learn from developers who have already shipped successful apps. What
+            worked and what would they do different?"
+          cta="View"
+        />
+        <InfoCard
+          to="/mastering-bitcoin-cash"
+          title="Mastering Bitcoin Cash"
+          text="Based on Mastering Bitcoin by Andreas M. Antonopoulos, Mastering
             Bitcoin Cash is the ultimate guide to the bring your knowledge from
-            beginner to professional step by step.
-          </Text>
-          <CTASection>
-            <StyledLink to="/mastering-bitcoin-cash">
-              <Text centerVertical bold>
-                Read <FaAngleRight />
-              </Text>
-            </StyledLink>
-          </CTASection>
-        </SectionItem>
+            beginner to professional step by step."
+          cta="Read"
+        />
       </SectionLayout>
     </Container>
   </DefaultLayout>

--- a/src/pages/learn.js
+++ b/src/pages/learn.js
@@ -10,12 +10,8 @@ import HelmetPlus from 'components/HelmetPlus'
 
 import InfoCard from 'components/InfoCard'
 
-import { FaAngleRight } from 'react-icons/fa'
-
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
-import StyledLink from 'atoms/StyledLink'
 
 import media from 'styles/media'
 import spacing from 'styles/spacing'

--- a/src/pages/slp.js
+++ b/src/pages/slp.js
@@ -14,7 +14,6 @@ import H2 from 'atoms/H2'
 import H1 from 'atoms/H1'
 import Button from 'atoms/Button'
 import Code from 'atoms/Code'
-import Pre from 'atoms/Pre'
 import StyledLink from 'atoms/StyledLink'
 
 import media from 'styles/media'

--- a/src/pages/tutorials.js
+++ b/src/pages/tutorials.js
@@ -10,9 +10,8 @@ import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
 import InfoCard from 'components/InfoCard'
 
-import { FaAngleRight, FaAngleLeft } from 'react-icons/fa'
+import { FaAngleLeft } from 'react-icons/fa'
 
-import Text from 'atoms/Text'
 import H3 from 'atoms/H3'
 import H1 from 'atoms/H1'
 import StyledLink from 'atoms/StyledLink'
@@ -36,14 +35,6 @@ const PreviewLayout = styled.div`
     grid-template-columns: .7fr;
   `};
 `
-
-const TutorialPreviewLayout = styled.div`
-  display: grid;
-  grid-gap: ${spacing.tiny};
-  padding-left: ${spacing.tiny};
-  border-left: 2px solid ${props => props.theme.primary};
-`
-const TutorialHeaderLayout = styled.div``
 
 type Props = {
   location: Object,

--- a/src/pages/tutorials.js
+++ b/src/pages/tutorials.js
@@ -8,6 +8,7 @@ import DefaultLayout from 'components/layouts/DefaultLayout'
 import Hero from 'components/Hero'
 import Container from 'components/Container'
 import HelmetPlus from 'components/HelmetPlus'
+import InfoCard from 'components/InfoCard'
 
 import { FaAngleRight, FaAngleLeft } from 'react-icons/fa'
 
@@ -17,6 +18,7 @@ import H1 from 'atoms/H1'
 import StyledLink from 'atoms/StyledLink'
 
 import spacing from 'styles/spacing'
+import media from 'styles/media'
 
 import HeroImg from 'images/learn-bitcoin-cash-header.jpg'
 
@@ -26,9 +28,13 @@ const HeroLayout = styled.div`
 `
 
 const PreviewLayout = styled.div`
-  margin-top: ${spacing.medium};
   display: grid;
+  padding-top: ${spacing.large};
   grid-gap: ${spacing.medium};
+  grid-template-columns: 1fr;
+  ${media.medium`
+    grid-template-columns: .7fr;
+  `};
 `
 
 const TutorialPreviewLayout = styled.div`
@@ -50,6 +56,7 @@ type Props = {
             updatedAt: string,
             createdAt: string,
           },
+          excerpt: string,
         },
       },
     },
@@ -90,19 +97,12 @@ const Tutorials = ({ location, data }: Props) => {
       <Container>
         <PreviewLayout>
           {tutorials.map((tutorial, idx) => (
-            <TutorialPreviewLayout key={idx}>
-              <TutorialHeaderLayout>
-                <StyledLink subtle to={tutorial.node.fields.slug}>
-                  <H3>{tutorial.node.frontmatter.title} </H3>
-                </StyledLink>
-              </TutorialHeaderLayout>
-              <Text>{tutorial.node.frontmatter.description}</Text>
-              <StyledLink to={tutorial.node.fields.slug}>
-                <Text bold centerVertical>
-                  Read <FaAngleRight />
-                </Text>
-              </StyledLink>
-            </TutorialPreviewLayout>
+            <InfoCard
+              to={tutorial.node.fields.slug}
+              title={tutorial.node.frontmatter.title}
+              text={tutorial.node.description || tutorial.node.excerpt}
+              cta="Read"
+            />
           ))}
         </PreviewLayout>
       </Container>

--- a/src/styles/themes.js
+++ b/src/styles/themes.js
@@ -5,6 +5,9 @@ import palette from './palette'
 const defaultTheme = {
   primary: palette.sun,
   primaryMuted: palette.oldLace,
+  primary500: '#fab915',
+  primary100: '#fdf6e3',
+  primary200: '#ded8c6',
   secondary: palette.buddhaGold,
   foreground: palette.woodsmoke,
   background: palette.white,


### PR DESCRIPTION
# Summary
* Some markdown formatting consistency
* whc/bch testnet faucet's using the site design/components
* Start of a larger color consistency pattern
* SLP button layout fix on homepage
* `develop` highlighted when on `SLP` and `faucets` related pages
* All grids use a consistent card styling
* Tutorials now show a preview of the post in the listings
* Code/ESLint cleanup

### Added a bit, ready for review