### PR TITLE
Bug - Link to our testnet explorer from faucet

### DIFF
--- a/src/components/bch-faucet.js
+++ b/src/components/bch-faucet.js
@@ -169,15 +169,15 @@ class BchFaucet extends React.PureComponent<Props, State> {
     }
   }
 
-  showLink(txid) {
+  showLink(txid: string) {
     this.setState(prevState => ({
       linkOn: true,
-      linkAddr: `https://www.blocktrail.com/tBCC/tx/${txid}`,
+      linkAddr: `https://explorer.bitcoin.com/tbch/tx/${txid}`,
     }))
   }
 
   // Add another line to the output.
-  addOutput = str => {
+  addOutput = (str: string) => {
     this.setState(prevState => ({
       outputText: prevState.outputText + `\n${str}`,
     }))

--- a/src/components/whc-faucet.js
+++ b/src/components/whc-faucet.js
@@ -174,10 +174,10 @@ class BchFaucet extends React.PureComponent<Props, State> {
     }
   }
 
-  showLink(txid) {
+  showLink(txid: string) {
     this.setState(prevState => ({
       linkOn: true,
-      linkAddr: `https://www.blocktrail.com/tBCC/tx/${txid}`,
+      linkAddr: `https://explorer.bitcoin.com/tbch/tx/${txid}`,
     }))
   }
 


### PR DESCRIPTION
Link to our own testnet explorer after dripping a faucet.

Fixes #134 