### PR TITLE
Add CashScript documentation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -47,6 +47,7 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       const isGui = filePath.includes('/gui/')
       const isRest = filePath.includes('/rest/')
       const isBadger = filePath.includes('/badger/')
+      const isCashScript = filePath.includes('/cashscript/')
 
       // get platform
       const isJs = filePath.includes('/js/')
@@ -80,6 +81,10 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       if (isBadger) {
         slug = `/badger/docs/${filename}`
         product = 'badger'
+      }
+      if (isCashScript) {
+        slug = `/cashscript/docs/${filename}`
+        product = 'cashscript'
       }
 
       createNodeField({

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -46,6 +46,7 @@ const developBaseUrls = [
   '/slp',
   '/faucets',
   '/badger',
+  '/cashscript',
 ]
 const learnBaseUrls = [
   '/learn',

--- a/src/data/docs/cashscript/cashc.md
+++ b/src/data/docs/cashscript/cashc.md
@@ -1,0 +1,29 @@
+---
+title: Cashc CLI
+icon: terminal
+ordinal: 1
+---
+
+`cashc` can be used to compile CashScript `.cash` files into `.json` artifact files. These artifacts can be imported and used by any of the CashScript SDKs, or other libraries / applications that utilise CashScript. Check out the [Language Documentation](/cashscript/docs/language) for a full overview of this Artifact format.
+
+### Installation
+
+You can use `npm` to install the `cashc` command line tool gloablly.
+
+```bash
+npm install -g cashc
+```
+
+### Usage
+
+The `cashc` CLI tool can be used to compile `.cash` files to JSON artifact files.
+
+```bash
+Usage: cashc [options] [source_file]
+
+Options:
+  --output, -o  Specify a file to output the generated artifact.
+                                                             [string] [required]
+  --help        Show help                                              [boolean]
+  --version     Show version number                                    [boolean]
+```

--- a/src/data/docs/cashscript/getting-started.md
+++ b/src/data/docs/cashscript/getting-started.md
@@ -1,0 +1,113 @@
+---
+title: Getting Started
+icon: home
+ordinal: 0
+---
+
+CashScript is a high level language enabling basic smart contract functionality on Bitcoin Cash. While these cash contracts are less powerful than Ethereum's smart contracts, CashScript was in many ways inspired by Ethereum's development ecosystem. Ethereum has always had one of the most accessible development ecosystems in terms of tooling, and with CashScript we want to bring that accessibility to Bitcoin Cash.
+
+---
+
+**Attention:** CashScript is in active development, and is currently in a `beta` phase. While CashScript is in `beta` stage, its APIs and usage is subject to change, so be sure to check the documentation. During the `beta` phase it is possible that the library still contains bugs, so for now the CashScript SDK can only be used on the `testnet` network.
+
+### The CashScript Language
+
+CashScript is a high-level language that allows you to write Cash Contracts in a straightforward and familiar way. It is inspired by Ethereum's Solidity, but it is not the same, and cash contracts work very differently from Ethereum's smart contracts. See the [Language Documentation](/cashscript/docs/language) for a full reference of the language.
+
+### The CashScript Compiler
+
+CashScript features a compiler as a standalone command line tool, called `cashc`. It can be installed through npm and used to compile `.cash` files into `.json` artifact files. These artifact files can be imported into the CashScript JavaScript SDK (or other SDKs in the future). Note that the CashScript SDK also has a fnuction to import and compile `.cash` files directly, so it is not required to use the `cashc` command line tool.
+
+See the [cashc documentation](/cashscript/docs/cashc) for more information on the `cashc` command line tool.
+
+#### Installation
+
+```bash
+npm install -g cashc
+```
+
+#### Usage
+
+```bash
+Usage: cashc [options] [source_file]
+
+Options:
+  --output, -o  Specify a file to output the generated artifact.
+                                                             [string] [required]
+  --help        Show help                                              [boolean]
+  --version     Show version number                                    [boolean]
+```
+
+### The CashScript SDK
+
+The main way to interact with cash contracts and integrate them into applications is using the CashScript SDK. This SDK allows you to compile `.cash` files or import `.json` artifact files, and convert them to `Contract` objects. These objects are used to create new contract instances. These instances are used to interact with the contracts using the functions that were implemented in the `.cash` file. For more information on the CashScript SDK, refer to the [full SDK documentation](/cashscript/docs/sdk).
+
+**Note:** The CashScript officially only supports NodeJS, as it uses some NodeJS-specific functionality (fs, path). We are working on making the library compatible with the browser as well as NodeJS, but this is **currently not supported**.
+
+#### Installation
+
+```bash
+npm install cashscript
+```
+
+#### Usage
+
+```ts
+import { Contract, ... } from 'cashscript';
+```
+
+```js
+const { Contract, ... } = require('cashscript');
+```
+
+Using the CashScript SDK, you can import / compile existing cash contract files, create new instances of these contracts, and interact with these instances:
+
+```ts
+...
+  // Compile the P2PKH Cash Contract
+  const P2PKH: Contract = Contract.fromCashFile(path.join(__dirname, 'p2pkh.cash'), 'testnet');
+
+  // Instantiate a new P2PKH contract with constructor arguments: { pkh: pkh }
+  const instance: Instance = P2PKH.new(pkh);
+
+  // Get contract balance & output address + balance
+  const contractBalance: number = await instance.getBalance();
+  console.log('contract address:', instance.address);
+  console.log('contract balance:', contractBalance);
+
+  // Call the spend function with the owner's signature
+  // And use it to send 0. 000 100 00 BCH back to the contract's address
+  const tx: TxnDetailsResult = await instance.functions.spend(pk, new Sig(keypair, 0x01))
+    .send(instance.address, 10000);
+  console.log('transaction details:', tx);
+...
+```
+
+### Examples
+
+If you want to see CashScript in action and check out its usage, there are several example contracts in the [CashScript repository](https://github.com/Bitcoin-com/cashscript/tree/master/examples). The `.cash` files contain example contracts, and the `.ts` files contain example usage of the CashScript SDK to interact with these contracts.
+
+The "Hello World" of cash contracts is defining the P2PKH pattern inside a cash contract, which can be found under [`examples/p2pkh.cash`](https://github.com/Bitcoin-com/cashscript/tree/master/examples/p2pkh.cash). Its usage can be found under [`examples/p2pkh.ts`](https://github.com/Bitcoin-com/cashscript/tree/master/examples/p2pkh.ts).
+
+#### Running the examples
+
+To run the examples, clone the [CashScript repository](https://github.com/Bitcoin-com/cashscript) and navigate to the `examples/` directory. Since the examples depend on the SDK, be sure to run `npm install` inside the `examples/` directory, which installs all required packages.
+
+```bash
+git clone git@github.com:Bitcoin-com/cashscript.git
+cd cashscript/examples
+npm install
+```
+
+All `.ts` files in the examples directory can then be executed with `ts-node`.
+
+```bash
+npm install -g ts-node
+ts-node p2pkh.ts
+```
+
+All `.js` files can be executed with `node`.
+
+```bash
+node p2pkh.js
+```

--- a/src/data/docs/cashscript/language.md
+++ b/src/data/docs/cashscript/language.md
@@ -1,0 +1,312 @@
+---
+title: CashScript Language
+icon: coins
+ordinal: 3
+---
+
+### Introduction
+
+The CashScript language allows you to write cash contracts in a very straightforward, readable, and maintainable way. It has a syntax similar to Ethereum's [Solidity language](https://solidity.readthedocs.io/), which is the most widespread smart contract language in the greater blockchain ecosystem. While Ethereum's smart contracts can be used for almost anything, Bitcoin Cash's cash contracts are much more limited in functionality, and instead they allow you to put complex spending conditions on your currency.
+
+Take the following example cash contract:
+
+```solidity
+contract TransferWithTimeout(
+    pubkey sender,
+    pubkey recipient,
+    int timeout
+) {
+    function transfer(sig recipientSig) {
+        require(checkSig(recipientSig, recipient));
+    }
+
+    function timeout(sig senderSig) {
+        require(checkSig(senderSig, sender));
+        require(tx.time >= timeout);
+    }
+}
+```
+
+A contract in CashScript is a collection of functions that can be used to spend the funds that are locked in this contract. These contracts can be instantiated using the contract's parameters, and their functions can be called by specifying the correct function parameters. The example used above is a simple value transfer that can be claimed by the recipient before a certain timeout, after which it can be reclaimed by the original sender. To instantiate this contract, the public keys of the sender and recipient should be passed as well as a timeout in the form of a block number.
+
+For the recipient to spend from this cash contract, they need to use the transfer function and provide a valid transaction signature using their keypair. For the sender to reclaim from this cash contract, they also need to provide a valid transaction signature using their keychain, but to the timeout function. In addition, the timeout function also checks that the block number in which this transaction is included is greater than or equal to the timeout value.
+
+### Control structures
+
+The only control structures are `if` and `else`, with loops and return statements left out due to their incompatibility with the underlying Bitcoin Script. If-else statements follow the usual semantics known from C or JavaScript.
+
+Parentheses can not be omitted for conditionals, but curly brances can be omitted around single-statement bodies.
+
+Note that there is no type conversion from non-boolean to boolean types as there is in C and JavaScript, so `if (1) { ... }` is not valid CashScript.
+
+### Types
+
+CashScript is a statically typed language, which means that the type of each variable needs to be specified. Types can interact with each other in expressions containing operators. For a quick reference of the various operators, see [Operators](/cashscript/docs/language#operators). Types can also be implicitly or explicitly casted to other types. For a quick reference of the various casting possibilities, see [Casting](/cashscript/docs/language#casting).
+
+#### Boolean
+
+`bool`: The possible values are constants true and false.
+
+Operators:
+
+- `!` (logical negation)
+- `&&` (logical conjunction, “and”)
+- `||` (logical disjunction, “or”)
+- `==` (equality)
+- `!=` (inequality)
+
+The operators `||` and `&&` don't apply common short-circuiting rules. This means that in the expression `f(x) || g(y)`, even if `f(x)` evaluates to true, `g(y)` will still be executed.
+
+#### Integer
+
+`int`: Signed integer of 32 bit size.
+
+Operators:
+
+- Comparisons: `<=`, `<`, `==`, `!=`, `>=`, `>` (evaluate to `bool`)
+- Arithmetic operators: `+`, `-`, unary `-`, `/`, `%` (modulo).
+
+Note the clear lack of the `*` and `**` (exponentation) operators as well as any bitwise operators.
+
+While integer sizes are limited to 32 bits, the output of arithmetic operations can exceed this size. This will not result in an overflow, but instead the script will fail when using this value in another integer operation. Division and modulo operations will fail if the right hand side of the expression is zero.
+
+#### String
+
+`string`: ASCII-encoded byte sequence.
+
+Operators:
+
+- `+` (concatenation)
+- `==` (equality)
+- `!=` (inequality)
+
+Members:
+
+- `length`: Number of characters that represent the string.
+- `split(int)`: Splits the string at the specified character and returns a tuple with the two resulting strings.
+
+#### Bytes
+
+`bytes`, `bytes20`, `bytes32`: Byte sequence, optionally bound to 20 or 32 bytes, which typically represent hashes.
+
+Operators:
+
+- `+` (concatenation)
+- `==` (equality)
+- `!=` (inequality)
+
+Members:
+
+- `length`: Number of characters that represent the string.
+- `split(int)`: Splits the string at the specified character and returns a tuple with the two resulting strings.
+
+#### Pubkey
+
+`pubkey`: Byte sequence representing a public key.
+
+Operators:
+
+- `==` (equality)
+- `!=` (inequality)
+
+#### Sig
+
+`sig`: Byte sequence representing a transaction signature.
+
+Operators:
+
+- `==` (equality)
+- `!=` (inequality)
+
+#### Datasig
+
+`datasig`: Byte sequence representing a data signature.
+
+Operators:
+
+- `==` (equality)
+- `!=` (inequality)
+
+#### Array & Tuple
+
+These types are not assignable, and only have very specific uses within CashScript.
+
+Arrays are only able to be passed into `checkMultisig` functions using the following syntax:
+
+```
+checkMultisig([sig1, sig2], [pk1, pk2, pk3]);
+```
+
+Tuples can only arise by using the `split` member function on a `string` or a `bytes` type. Their first or second element can be accessed through a familiar array indexing syntax:
+
+```
+string question = "What is Bitcoin Cash?";
+string answer = question.split(15)[0].split(8)[1];
+```
+
+### Functions & Globals
+
+#### Arithmetic functions
+
+**`int abs(int a)`**
+
+Returns the absolute value of argument `a`.
+
+**`int min(int a, int b)`**
+
+Returns the minimum value of arguments `a` and `b`.
+
+**`int max(int a, int b)`**
+
+Retuns the maximum value of arguments `a` and `b`.
+
+**`bool within(int x, int lower, int upper)`**
+
+Returns `true` if and only if `x >= lower && x < upper`.
+
+#### Hashing functions
+
+**`bytes20 ripemd160(any x)`**
+
+Returns the RIPEMD-160 hash of argument `x`.
+
+**`bytes32 sha1(any x)`**
+
+Returns the SHA-1 hash of argument `x`.
+
+**`bytes32 sha256(any x)`**
+
+Returns the SHA-256 hash of argument `x`.
+
+**`bytes20 hash160(any x)`**
+
+Returns the RIPEMD-160 hash of the SHA-256 hash of argument `x`.
+
+**`bytes32 hash256(any x)`**
+
+Returns the double SHA-256 hash of argument `x`.
+
+#### Signature checking functions
+
+**`bool checksig(sig s, pubkey pk)`**
+
+Checks that transaction signature `s` is valid for the current transaction and matches with public key `pk`.
+
+**`bool checkMultiSig(sig[] sigs, pubkey[] pks)`**
+
+Performs a multi-signature check using a list of transaction signatures and public keys.
+
+**Note**: While this function is compiled correctly and can be used, it is not supported by the JavaScript SDK, so it is recommended not to use `checkMultiSig` at the moment.
+
+**`bool checkDataSig(datasig s, bytes msg, pubkey pk)`**
+
+Checks that sig `s` is a valid signature for message `msg` and matches with public key `pk`.
+
+#### Error handling
+
+**`void require(bool condition)`**
+
+Asserts that boolean expression `condition` evaluates to `true`. If it evaluates to `false`, the script fails. As this function has a `void` return type, it can only be used as a standalone statement.
+
+#### Global variables
+
+**`tx.time`**
+
+Represents the block number that the transaction is included in. It can also represent the timestamp of the transaction when so configured in the transaction. The JavaScript SDK only has support for block number right now though, so it is recommended to only use it as the block number.
+
+Due to limitations in the underlying Bitcoin Script, `tx.time` can only be used in the following way:
+
+```solidity
+require(tx.time >= <expression>);
+```
+
+**`tx.age`**
+
+Represents the block depth of the utxo that is being spent by the current transaction. It can also represent the utxo's age in seconds when so configured in the transaction. The JavaScript SDK only has support for block depth right now though so it is recommended to only use it as the block depth.
+
+Due to limitations in the underlying Bitcoin Script, `tx.age` can only be used in the following way:
+
+```solidity
+require(tx.age >= <expression>);
+```
+
+### Operators
+
+| Precedence | Description                     | Operator                |
+| ---------- | ------------------------------- | ----------------------- |
+| 1          | Parentheses                     | `(<expression>)`        |
+| 2          | Type cast                       | `<type>(<expression>)`  |
+| 3          | Function call                   | `<function>(<args...>)` |
+| 4          | Tuple index                     | `<tuple>[<index>]`      |
+| 5          | Member access                   | `<object>.<member>`     |
+| 6          | Postfix increment and decrement | `++`, `--`              |
+| 7          | Unary minus                     | `-`                     |
+| 7          | Logical NOT                     | `!`                     |
+| 8          | Division and modulo             | `/`, `%`                |
+| 9          | Addition and subtraction        | `+`, `-`                |
+| 9          | String / bytes concatenation    | `+`                     |
+| 10         | Numeric comparison              | `<`, `>`, `<=`, `>=`    |
+| 11         | Equality and inequality         | `==`, `!=`              |
+| 12         | Logical AND                     | `&&`                    |
+| 13         | Logical OR                      | `||`                    |
+| 14         | Assignment                      | `=`                     |
+
+### Casting
+
+Type casting is done using a syntax similar to function calls, but using a type name instead of a function name.
+
+```solidity
+pubkey pk = pubkey(0x0000);
+```
+
+See the following table for information on which types can be cast to other which other types.
+
+| Type    | Implicitly castable to | Explicitly castable to             |
+| ------- | ---------------------- | ---------------------------------- |
+| int     |                        | bytes, bytes20, bytes32, bool      |
+| bool    |                        | int                                |
+| string  |                        | bytes                              |
+| bytes   |                        | bytes20, bytes32, sig, pubkey, int |
+| bytes20 | bytes, bytes32         | bytes, bytes32                     |
+| bytes32 | bytes                  | bytes                              |
+| pubkey  | bytes                  | bytes                              |
+| sig     | bytes                  | bytes, datasig                     |
+| datasig | bytes                  | bytes                              |
+
+### Artifacts
+
+Compiled cash contracts can be represented by so-called artifacts. These artifacts can be stored in `.json` files so they can be shared and stored for later usage without recompilation. These artifacts allow any third-party SDKs to be developed, as they only need to be able to import and use an artifact file, while leaving the compilation to the `cashc` command line tool.
+
+#### Artifact specification
+
+```ts
+interface Artifact {
+  contractName: string // Contract name
+  constructorInputs: AbiInput[] // Arguments required to instantiate a contract
+  abi: AbiFunction[] // functions that can be called
+  bytecode: string // Compiled Script without constructor parameters added (in ASM format)
+  source: string // Source code of the CashScript contract
+  networks: {
+    // Dictionary per network (testnet / mainnet)
+    [network: string]: {
+      // Dictionary of contract addresses with the corresponding compiled script (in ASM format)
+      [address: string]: string
+    }
+  }
+  compiler: {
+    name: string // Compiler used to compile this contract
+    version: string // Compiler version used to compile this contract
+  }
+  updatedAt: string // Last datetime this artifact was updated (in ISO format)
+}
+
+interface AbiInput {
+  name: string // Input name
+  type: string // Input type (see language documentation)
+}
+
+interface AbiFunction {
+  name: string // Function name
+  inputs: AbiInput[] // Function inputs / parameters
+}
+```

--- a/src/data/docs/cashscript/sdk.md
+++ b/src/data/docs/cashscript/sdk.md
@@ -1,0 +1,162 @@
+---
+title: CashScript SDK Reference
+icon: code
+ordinal: 2
+---
+
+### Contract
+
+The `Contract` class allows you to compile CashScript files into `Contract` objects, from which these contracts can be instantiated and interacted with. These `Contract` objects can also be imported from a JSON Artifact file, and exported to one, which allows you to store and transfer the contract definition in JSON format, so you don't need to recompile the contract every time you use it. For more information on Artifacts, see the [Language Documentation](/cashscript/docs/language).
+
+#### Creating a Contract object
+
+Before instantiating a contract, first you need to create a new `Contract` object. This can be done by compiling a CashScript file, or by importing an Artifact file that was exported previously.
+
+**`Contract.fromCashFile(fn: string, network?: string): Contract`**
+
+Compiles the CashScript file found at the path specified by argument `fn`. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
+
+```ts
+const P2PKH: Contract = Contract.fromCashFile(
+  path.join(__dirname, 'p2pkh.cash'),
+  'testnet'
+)
+```
+
+**`Contract.fromArtifact(fn: string, network?: string): Contract`**
+
+Imports an Artifact file that was compiled previously. This file is found at the path specified by argument `fn`. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
+
+```ts
+const P2PKH: Contract = Contract.fromArtifact(
+  path.join(__dirname, 'p2pkh.cash'),
+  'testnet'
+)
+```
+
+#### Exporting a contract
+
+A `Contract` object can be exported to an Artifact file to be imported at a later moment, so it can be stored or transfered more easily, and can be used without recompilation. If the object is exported after one or more new contracts have been instantiated, their details will be stored in the file as well so they can be easily accessed later on.
+
+**`contract.export(fn: string): void`**
+
+Writes the contract's details to an Artifact file found at the location specified by argument `fn`, so it can be retrieved later. If the file does not exist yet, it is created. If the file already exists, **it is overwritten**.
+
+```ts
+P2PKH.export(path.join(__dirname, 'p2pkh.json'))
+```
+
+#### Instantiating a contract
+
+After creating a `Contract` object through compilation or import, this contract can be instantiated. If any contracts were instantiated before and this information was stored, these instances can also be accessed.
+
+**`contract.new(...parameters: Parameter[]): Instance`**
+
+This function is derived by looking at the contract parameters specified inside the contract's CashScript file, and to call it the parameters need to match those specified in contract code.
+
+```ts
+const instance: Instance = P2PKH.new(pkh)
+```
+
+**`contract.deployed(at?: string): Instance`**
+
+Looks up the address specified by argument `at` and returns the instance that belongs to the address if it exists. If `at` is omitted it returns the first instance that it finds.
+
+```ts
+const instance: Instance = P2PKH.deployed()
+const instance: Instance = P2PKH.deployed(
+  'bchtest:ppzllwzk775qk86zfskzyzae7pa9h4dvzcfezpsdkl'
+)
+```
+
+### Instance
+
+After instantiating a new contract or retrieving a previously deployed one, this instance can be interacted with using the functions implemented in the `.cash` file.
+
+**`instance.address`**
+
+An instance's address can be retrieved through the `address` member field.
+
+```ts
+console.log(instance.address)
+```
+
+**`async instance.getBalance(): Promise<number>`**
+
+Returns the total balance of the contract in satoshis. This incudes confirmed and unconfirmed balance.
+
+```ts
+const contractBalance: number = await instance.getBalance()
+```
+
+**`instance.functions.<functionName>(...parameters: Parameter[]): Transaction`**
+
+All contract functions defined in your CashScript file can be found by their name under the `functions` member field of an instance. To call them, the parameters need to match the ones defined in your CashScript file.
+
+```ts
+const tx = await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .send(instance.address, 10000)
+```
+
+**A note on transaction signatures:**
+
+Some cash contract functions require a signature parameter, which needs to be a valid transaction signature for the current transaction. The current transaction details are unknown at the time of calling a contract function. This is why we have a separate `Sig` class made up of a keypair and hashtype, that represents a placeholder for these signatures. These placeholders are automatically replaced by the correct signature during the transaction building phase.
+
+**`new Sig(keypair: ECPair, hashtype: number)`**
+
+Creates a placeholder for a transaction signature of the current transaction. During the transaction building phase this placeholder is replaced by the actual signature.
+
+```ts
+new Sig(keypair, 0x01)
+```
+
+### Transaction
+
+Calling any of the contract functions on a contract instance results in a `Transaction` object, which can be sent by specifying a recipient and amount to send, or a list of these pairs. The `send` functiion calls can also be replaced by `meep` function calls to output the debug command to debug the transaction using [meep](https://github.com/gcash/meep).
+
+**`async transaction.send(to: string, amount: number): Promise<TxnDetailsResult>`**
+
+Sends a transaction for an amount denoted in satoshis by argument `amount` to an address specified by argument `to`. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
+
+```ts
+const tx = await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .send(instance.address, 10000)
+```
+
+**`async transaction.send({ to: string, amount: number }[]): Promise<TxnDetailsResult>`**
+
+Sends a transaction with multiple outputs to multiple address-amount pairs specified by the list of `{ to: string, amount: number }` objects. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
+
+```ts
+const tx = await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .send([
+    { to: instance.address, amount: 10000 },
+    { to: instance.address, amount: 20000 },
+  ])
+```
+
+**`async transaction.meep(to: string, amount: number): Promise<void>`**
+
+Prints the `meep` command that can be used to debug the transaction resulting from using the `send` function.
+
+```ts
+await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .meep(instance.address, 10000)
+```
+
+**`async transaction.meep({ to: string, amount: number }[]): Promise<void>`**
+
+Prints the `meep` command that can be used to debug the transaction resulting from using the `send` function.
+
+```ts
+await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .meep([
+    { to: instance.address, amount: 10000 },
+    { to: instance.address, amount: 20000 },
+  ])
+```

--- a/src/pages/develop.js
+++ b/src/pages/develop.js
@@ -85,6 +85,12 @@ const DevelopPage = ({ location, data }: Props) => (
           cta="View"
         />
         <InfoCard
+          to="/cashscript/docs/getting-started"
+          title="CashScript"
+          text="Create contracts and complex spending scripts on Bitcoin Cash. Everything you need to write cash contracts and easily integrate them into your applications."
+          cta="View"
+        />
+        <InfoCard
           to="/gui"
           title="GUI"
           text="BIP44 development wallet. Convert between cashaddr/legacy addresses. Create QR codes for WIF, XPub and XPrivs. Sign and verify messages."

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -151,6 +151,11 @@ const IndexPage = ({ location, data }: Props) => (
                 <Button round>Badger SDK</Button>
               </StyledLink>
             </HeroButtonItem>
+            <HeroButtonItem>
+              <StyledLink to="/cashscript/docs/getting-started">
+                <Button round>CashScript</Button>
+              </StyledLink>
+            </HeroButtonItem>
           </HeroButtonLayout>
         </HeroBlurbLayout>
         <SDKLayout>

--- a/src/templates/docPage.js
+++ b/src/templates/docPage.js
@@ -132,6 +132,7 @@ class DocTemplate extends React.PureComponent<Props> {
       gui: '/gui/docs/getting-started',
       rest: '/rest/docs/getting-started',
       slp: '/slp/docs/js/getting-started',
+      cashscript: '/cashscript/docs/getting-started',
     }[event.target.value]
 
     pageTarget && push(pageTarget)
@@ -181,6 +182,9 @@ class DocTemplate extends React.PureComponent<Props> {
                     <option value="rest">{getTitleDisplay('rest')}</option>
                     <option value="gui">{getTitleDisplay('gui')}</option>
                     <option value="slp">{getTitleDisplay('slp')}</option>
+                    <option value="cashscript">
+                      {getTitleDisplay('cashscript')}
+                    </option>
                   </Select>
                 </NavFooter>
               </SideNavSticky>

--- a/src/utils/formatting.js
+++ b/src/utils/formatting.js
@@ -6,6 +6,7 @@ const titleMap = {
   gui: 'GUI',
   slp: 'SLP',
   badger: 'Badger',
+  cashscript: 'CashScript',
   other: 'Other',
 }
 export const getTitleDisplay = (product: string) => {


### PR DESCRIPTION
- Add pages for cashc, cashscript sdk, cashscript language, and getting started

I use inline code for the subheaders for function documentation. I need these subheaders to be seen as inline code for the structure of the document. But when they are longer than 25 characters they are converted from inline code to a code block.

I found this code:

```js
// Short use inline custom component, long use codeblock
const CodePreSplitter = ({ children }: BasicProps) => {
  if (children && children[0].length > 25) {
    return <Code fontSize={14}>{children}</Code>
  }
  return <Pre>{children}</Pre>
}
```

Would there be a way to keep my inline code as inline code regardless of the length?