### PR TITLE
Update CashScript documentation

### DIFF
--- a/src/data/docs/cashscript/getting-started.md
+++ b/src/data/docs/cashscript/getting-started.md
@@ -65,7 +65,7 @@ Using the CashScript SDK, you can import / compile existing cash contract files,
 ```ts
 ...
   // Compile the P2PKH Cash Contract
-  const P2PKH: Contract = Contract.fromCashFile(path.join(__dirname, 'p2pkh.cash'), 'testnet');
+  const P2PKH: Contract = Contract.compile(path.join(__dirname, 'p2pkh.cash'), 'testnet');
 
   // Instantiate a new P2PKH contract with constructor arguments: { pkh: pkh }
   const instance: Instance = P2PKH.new(pkh);

--- a/src/data/docs/cashscript/getting-started.md
+++ b/src/data/docs/cashscript/getting-started.md
@@ -77,7 +77,7 @@ Using the CashScript SDK, you can import / compile existing cash contract files,
 
   // Call the spend function with the owner's signature
   // And use it to send 0. 000 100 00 BCH back to the contract's address
-  const tx: TxnDetailsResult = await instance.functions.spend(pk, new Sig(keypair, 0x01))
+  const tx: TxnDetailsResult = await instance.functions.spend(pk, new Sig(keypair))
     .send(instance.address, 10000);
   console.log('transaction details:', tx);
 ...

--- a/src/data/docs/cashscript/language.md
+++ b/src/data/docs/cashscript/language.md
@@ -8,9 +8,13 @@ ordinal: 3
 
 The CashScript language allows you to write cash contracts in a very straightforward, readable, and maintainable way. It has a syntax similar to Ethereum's [Solidity language](https://solidity.readthedocs.io/), which is the most widespread smart contract language in the greater blockchain ecosystem. While Ethereum's smart contracts can be used for almost anything, Bitcoin Cash's cash contracts are much more limited in functionality, and instead they allow you to put complex spending conditions on your currency.
 
+### Structure of a contract file
+
 Take the following example cash contract:
 
 ```solidity
+pragma cashscript ^0.2.0;
+
 contract TransferWithTimeout(
     pubkey sender,
     pubkey recipient,
@@ -26,6 +30,8 @@ contract TransferWithTimeout(
     }
 }
 ```
+
+A contract file may start with a pragma directive to indicate the language version the contract was written for. This ensures that a contract is not compiled using the wrong compiler version, which could be a cause of unintended effects. The pragma directive follows regular [semantic versioning rules](https://semver.npmjs.com/).
 
 A contract in CashScript is a collection of functions that can be used to spend the funds that are locked in this contract. These contracts can be instantiated using the contract's parameters, and their functions can be called by specifying the correct function parameters. The example used above is a simple value transfer that can be claimed by the recipient before a certain timeout, after which it can be reclaimed by the original sender. To instantiate this contract, the public keys of the sender and recipient should be passed as well as a timeout in the form of a block number.
 

--- a/src/data/docs/cashscript/language.md
+++ b/src/data/docs/cashscript/language.md
@@ -39,6 +39,10 @@ Parentheses can not be omitted for conditionals, but curly brances can be omitte
 
 Note that there is no type conversion from non-boolean to boolean types as there is in C and JavaScript, so `if (1) { ... }` is not valid CashScript.
 
+### Comments
+
+Comments can be added anywhere in the contract file. Comment semantics are similar to languages like JavaScript or C. This means that single-line comments can be added with `// ...`, while multiline comments can be added with `/* ... */`.
+
 ### Types
 
 CashScript is a statically typed language, which means that the type of each variable needs to be specified. Types can interact with each other in expressions containing operators. For a quick reference of the various operators, see [Operators](/cashscript/docs/language#operators). Types can also be implicitly or explicitly casted to other types. For a quick reference of the various casting possibilities, see [Casting](/cashscript/docs/language#casting).
@@ -144,6 +148,15 @@ string question = "What is Bitcoin Cash?";
 string answer = question.split(15)[0].split(8)[1];
 ```
 
+### Variables
+
+Variables can be declared by specifying their type and their name. All variables need to be initialised at their time of declaration, but they can be reassigned later on, so it is possible to specifically initialise variables to zero. Since CashScript is strongly typed and has no type inference, it is not possible to use keywords such as `var` or `let` to declare variables, as might be possible in different languages such as JavaScript.
+
+```
+int myNumber = 3000;
+string myString = 'Bitcoin Cash';
+```
+
 ### Functions & Globals
 
 #### Arithmetic functions
@@ -188,6 +201,8 @@ Returns the double SHA-256 hash of argument `x`.
 
 #### Signature checking functions
 
+**Note:** All signature checking functions must comply with the [NULLFAIL](https://github.com/bitcoin/bips/blob/master/bip-0146.mediawiki) rule. This rule implies that if you want to use the output of a signature check inside the condition of an if-statement, the input signature needs to either be correct, or an empty byte array. When you use a valid but incorrect signature as in input, the script will fail immediately.
+
 **`bool checksig(sig s, pubkey pk)`**
 
 Checks that transaction signature `s` is valid for the current transaction and matches with public key `pk`.
@@ -207,6 +222,25 @@ Checks that sig `s` is a valid signature for message `msg` and matches with publ
 **`void require(bool condition)`**
 
 Asserts that boolean expression `condition` evaluates to `true`. If it evaluates to `false`, the script fails. As this function has a `void` return type, it can only be used as a standalone statement.
+
+#### Units
+
+An integer literal can take a suffix of either monetary or temporary units to add smeantic value to these integers and to simplify arithmetic. When these units are used, the underlying integer is automatically multiplied by the value of the unit. The units `sats`, `finney`, `bits` and `bitcoin` are used to denote monetary value, while the units `seconds`, `minutes`, `hours`, `days` and `weeks` are used to denote time.
+
+```
+require(1 sats == 1);
+require(1 finney == 10);
+require(1 bit == 100);
+require(1 bitcoin == 1e8);
+
+require(1 seconds == 1);
+require(1 minutes == 60 seconds);
+require(1 hours == 60 minutes);
+require(1 days == 24 hours);
+require(1 weeks == 7 days);
+```
+
+Be careful when using these units in precise calendar calculations though, because not every year equals 365 days and not even every minute has 60 seconds because of [leap seconds](https://en.wikipedia.org/wiki/Leap_second).
 
 #### Global variables
 

--- a/src/data/docs/cashscript/language.md
+++ b/src/data/docs/cashscript/language.md
@@ -93,11 +93,11 @@ Operators:
 Members:
 
 - `length`: Number of characters that represent the string.
-- `split(int)`: Splits the string at the specified character and returns a tuple with the two resulting strings.
+- `split(int)`: Splits the string at the specified index and returns a tuple with the two resulting strings.
 
 #### Bytes
 
-`bytes`, `bytes20`, `bytes32`: Byte sequence, optionally bound to 20 or 32 bytes, which typically represent hashes.
+`bytes`: Byte sequence. Can optionally be bound to a certain byte length by specifying e.g. `bytes5`, `bytes32`, etc.
 
 Operators:
 
@@ -107,8 +107,8 @@ Operators:
 
 Members:
 
-- `length`: Number of characters that represent the string.
-- `split(int)`: Splits the string at the specified character and returns a tuple with the two resulting strings.
+- `length`: Number of bytes in the sequence.
+- `split(int)`: Splits the byte sequence at the specified index and returns a tuple with the two resulting byte sequences.
 
 #### Pubkey
 

--- a/src/data/docs/cashscript/language.md
+++ b/src/data/docs/cashscript/language.md
@@ -248,7 +248,7 @@ require(1 weeks == 7 days);
 
 Be careful when using these units in precise calendar calculations though, because not every year equals 365 days and not even every minute has 60 seconds because of [leap seconds](https://en.wikipedia.org/wiki/Leap_second).
 
-#### Global variables
+#### Global time variables
 
 **`tx.time`**
 
@@ -270,26 +270,98 @@ Due to limitations in the underlying Bitcoin Script, `tx.age` can only be used i
 require(tx.age >= <expression>);
 ```
 
+#### Global covenant variables
+
+Covenant variables are used to put constraints on the money inside the smart contract. This can be used to limit the addresses where money can be sent for example.
+
+This technique works by passing the sighash preimage into the smart contract and extracting the individual fields. Because this sighash preimage needs to be verified, **it is mandatory** to include a `require(checkSig(sig, pubkey));` statement anywhere in the code when using these covenant variables. This statement will be used by the compiler to verify the validity of the passed preimage. Using the CashScript SDK, this preimage is passed in automatically by the SDK, but when constructing transactions manually, be sure to include the preimage as a parameter.
+
+See [BIP143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#specification) and [Bitcoin Cash replay protected sighash](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md#digest-algorithm) for more technical documentation of the contents of all covenant variables. Note that the explanation of the variables below are using the default `hashtype` of `0x41`. Other hashtypes might assign different meaning to these variables. If it is important to use a specific hashtype, this can be enforce with `require(tx.hashtype == 0x41);`.
+
+**`tx.version (bytes4)`**
+
+Represents the version of the current transaction. Different transaction versions can have differences in functionality. Currently only version 1 and 2 exist, where only version 2 has support for [BIP68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki). Note that `tx.version` is of type `bytes4` so to use it as an integer it needs to be cast to `int`: `int(tx.version)`.
+
+**`tx.hashPrevouts (bytes32)`**
+
+Represents the double sha256 of the serialisation of all input outpoints.
+
+**`tx.hashSequence (bytes32)`**
+
+Represents the double sha256 of the serialisation of `nSequence` of all inputs.
+
+**`tx.outpoint (bytes36)`**
+
+Represents the outpoint of the current input (`bytes32` txid concatenated with `bytes4` vout).
+
+**`tx.bytecode (bytes)`**
+
+Represents the Bitcoin Script bytecode of the current contract. This can be used to enforce sending money back to the contract in combination with `tx.hashOutputs`.
+
+```solidity
+bytes32 output = new OutputP2SH(bytes8(10000), hash160(tx.bytecode));
+require(hash256(output) == tx.hashOutputs);
+```
+
+**`tx.value (bytes8)`**
+
+Represents the value of current input being spent. This can be used to enforce the full balance or a specific part of the contract's balance to be spent. Note that `tx.value` is of type `bytes8`, which is over the size limit for casting to integer, so to cast it to an integer it needs to be cast through a regular `bytes` type: `int(bytes(tx.value))`. Due to technical limitations, this can only work if `tx.value` fits within a 32-bit signed integer (max ~21 BCH).
+
+**`tx.sequence (bytes4)`**
+
+Represents the `nSequence` field of the current input.
+
+**`tx.hashOutputs (bytes32)`**
+
+Represents the double sha256 of the serialisation of all outputs (`bytes8` amount + `bytes` locking script). Can be used to enforce sending specific amounts to specific addresses.
+
+```solidity
+bytes34 out1 = new OutputP2PKH(bytes8(10000), pkh);
+bytes32 out2 = new OutputP2SH(bytes8(10000), hash160(tx.bytecode));
+require(hash256(out1 + out2) == tx.hashOutputs);
+```
+
+**`tx.locktime (bytes4)`**
+
+Represents the `nLocktime` field of the current input.
+
+**`tx.hashtype (bytes4)`**
+
+Represents the hashtype used for the generation of the sighash and signature. Can be used to enforce that the spender uses a specific hashtype. See [replay protected sighash](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md#digest-algorithm) for the implications of different hashtypes.
+
+### Object instantiation
+
+To assist with enforcing outputs, there are output variables that can be instantiated. These outputs can then be used together with `tx.hashOutputs` to enforce sending to these outputs. See the documentation for `tx.hashOutputs` in the section above.
+
+**`new OutputP2PKH(bytes8 amount, bytes20 pkh): bytes34`**
+
+Creates new P2PKH output serialisation for an output sending `amount` to `pkh`.
+
+**`new OutputP2SH(bytes8 amount, bytes20 scriptHash): bytes32`**
+
+Creates new P2SH output serialisation for an output sending `amount` to `scriptHash`.
+
 ### Operators
 
-| Precedence | Description                     | Operator                |
-| ---------- | ------------------------------- | ----------------------- |
-| 1          | Parentheses                     | `(<expression>)`        |
-| 2          | Type cast                       | `<type>(<expression>)`  |
-| 3          | Function call                   | `<function>(<args...>)` |
-| 4          | Tuple index                     | `<tuple>[<index>]`      |
-| 5          | Member access                   | `<object>.<member>`     |
-| 6          | Postfix increment and decrement | `++`, `--`              |
-| 7          | Unary minus                     | `-`                     |
-| 7          | Logical NOT                     | `!`                     |
-| 8          | Division and modulo             | `/`, `%`                |
-| 9          | Addition and subtraction        | `+`, `-`                |
-| 9          | String / bytes concatenation    | `+`                     |
-| 10         | Numeric comparison              | `<`, `>`, `<=`, `>=`    |
-| 11         | Equality and inequality         | `==`, `!=`              |
-| 12         | Logical AND                     | `&&`                    |
-| 13         | Logical OR                      | `||`                    |
-| 14         | Assignment                      | `=`                     |
+| Precedence | Description                     | Operator                 |
+| ---------- | ------------------------------- | ------------------------ |
+| 1          | Parentheses                     | `(<expression>)`         |
+| 2          | Type cast                       | `<type>(<expression>)`   |
+| 3          | Object instantiation            | `new <class>(<args...>)` |
+| 4          | Function call                   | `<function>(<args...>)`  |
+| 5          | Tuple index                     | `<tuple>[<index>]`       |
+| 6          | Member access                   | `<object>.<member>`      |
+| 7          | Postfix increment and decrement | `++`, `--`               |
+| 8          | Unary minus                     | `-`                      |
+| 8          | Logical NOT                     | `!`                      |
+| 9          | Division and modulo             | `/`, `%`                 |
+| 10         | Addition and subtraction        | `+`, `-`                 |
+| 10         | String / bytes concatenation    | `+`                      |
+| 11         | Numeric comparison              | `<`, `>`, `<=`, `>=`     |
+| 12         | Equality and inequality         | `==`, `!=`               |
+| 13         | Logical AND                     | `&&`                     |
+| 14         | Logical OR                      | `||`                     |
+| 15         | Assignment                      | `=`                      |
 
 ### Casting
 
@@ -347,6 +419,7 @@ interface AbiInput {
 
 interface AbiFunction {
   name: string // Function name
+  covenant: boolean // Does this function use covenant variables
   inputs: AbiInput[] // Function inputs / parameters
 }
 ```

--- a/src/data/docs/cashscript/sdk.md
+++ b/src/data/docs/cashscript/sdk.md
@@ -1,5 +1,5 @@
 ---
-title: CashScript SDK Reference
+title: CashScript SDK
 icon: code
 ordinal: 2
 ---
@@ -115,6 +115,19 @@ new Sig(keypair, 0x01)
 
 Calling any of the contract functions on a contract instance results in a `Transaction` object, which can be sent by specifying a recipient and amount to send, or a list of these pairs. The `send` functiion calls can also be replaced by `meep` function calls to output the debug command to debug the transaction using [meep](https://github.com/gcash/meep).
 
+The CashScript SDK supports transactions to regular addresses, as well as OP_RETURN outputs. To do so we define two different kind of outputs:
+
+```ts
+interface Recipient {
+  to: string
+  amount: number
+}
+interface OpReturn {
+  opReturn: string[]
+}
+type Output = Recipient | OpReturn
+```
+
 **`async transaction.send(to: string, amount: number): Promise<TxnDetailsResult>`**
 
 Sends a transaction for an amount denoted in satoshis by argument `amount` to an address specified by argument `to`. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
@@ -125,7 +138,7 @@ const tx = await instance.functions
   .send(instance.address, 10000)
 ```
 
-**`async transaction.send({ to: string, amount: number }[]): Promise<TxnDetailsResult>`**
+**`async transaction.send(Output[]): Promise<TxnDetailsResult>`**
 
 Sends a transaction with multiple outputs to multiple address-amount pairs specified by the list of `{ to: string, amount: number }` objects. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
 
@@ -135,6 +148,17 @@ const tx = await instance.functions
   .send([
     { to: instance.address, amount: 10000 },
     { to: instance.address, amount: 20000 },
+  ])
+```
+
+These transactions can include outputs to other addresses as well as OP_RETURN outputs:
+
+```ts
+const tx = await instance.functions
+  .spend(pk, new Sig(keypair, 0x01))
+  .send([
+    { opReturn: ['0x6d02', 'Hello World!'] },
+    { to: instance.address, amount: 10000 },
   ])
 ```
 
@@ -148,7 +172,7 @@ await instance.functions
   .meep(instance.address, 10000)
 ```
 
-**`async transaction.meep({ to: string, amount: number }[]): Promise<void>`**
+**`async transaction.meep(Output[]): Promise<void>`**
 
 Prints the `meep` command that can be used to debug the transaction resulting from using the `send` function.
 

--- a/src/data/docs/cashscript/sdk.md
+++ b/src/data/docs/cashscript/sdk.md
@@ -105,7 +105,7 @@ Some cash contract functions require a signature parameter, which needs to be a 
 
 **`new Sig(keypair: ECPair, hashtype?: HashType)`**
 
-Creates a placeholder for a transaction signature of the current transaction. During the transaction building phase this placeholder is replaced by the actual signature.
+Creates a placeholder for a transaction signature of the current transaction. During the transaction building phase this placeholder is replaced by the actual signature. **Important**: When calling a function that uses covenant variables, the first `Sig` parameter will be used to generate and pass in the sighash preimage as parameter.
 
 ```ts
 new Sig(keypair, HashType.SIGHASH_ALL)
@@ -128,7 +128,21 @@ interface OpReturn {
 type Output = Recipient | OpReturn
 ```
 
-**`async transaction.send(to: string, amount: number): Promise<TxnDetailsResult>`**
+**Transaction options**
+
+Optionally, options can be passed into all `send` function documented below, which can influence the transaction.
+
+```ts
+interface TxOptions {
+  time?: number
+  age?: number
+  fee?: number
+}
+```
+
+`time` sets the transaction `locktime` field in blocks, which corresponds with the `tx.time` global CashScript variable. `age` sets the transaction `sequence` field in blocks, which corresponds with the `tx.age` global CashScript variable. `fee` sets a hardcoded transaction fee, which can be used when the smart contract depends on the transaction having a specific fee.
+
+**`async transaction.send(to: string, amount: number, options?: TxOptions): Promise<TxnDetailsResult>`**
 
 Sends a transaction for an amount denoted in satoshis by argument `amount` to an address specified by argument `to`. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
 
@@ -138,7 +152,7 @@ const tx = await instance.functions
   .send(instance.address, 10000)
 ```
 
-**`async transaction.send(Output[]): Promise<TxnDetailsResult>`**
+**`async transaction.send(Output[], options?: TxOptions): Promise<TxnDetailsResult>`**
 
 Sends a transaction with multiple outputs to multiple address-amount pairs specified by the list of `{ to: string, amount: number }` objects. This sends the transaction to the `rest.bitcoin.com` servers to be included in the Bitcoin Cash blockchain. Returns the raw `TxnDetailsResult` object as returned by `rest.bitcoin.com`.
 
@@ -162,7 +176,7 @@ const tx = await instance.functions
   ])
 ```
 
-**`async transaction.meep(to: string, amount: number): Promise<void>`**
+**`async transaction.meep(to: string, amount: number, options?: TxOptions): Promise<void>`**
 
 Prints the `meep` command that can be used to debug the transaction resulting from using the `send` function.
 
@@ -172,7 +186,7 @@ await instance.functions
   .meep(instance.address, 10000)
 ```
 
-**`async transaction.meep(Output[]): Promise<void>`**
+**`async transaction.meep(Output[], options?: TxOptions): Promise<void>`**
 
 Prints the `meep` command that can be used to debug the transaction resulting from using the `send` function.
 

--- a/src/data/docs/cashscript/sdk.md
+++ b/src/data/docs/cashscript/sdk.md
@@ -95,20 +95,20 @@ All contract functions defined in your CashScript file can be found by their nam
 
 ```ts
 const tx = await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .send(instance.address, 10000)
 ```
 
 **A note on transaction signatures:**
 
-Some cash contract functions require a signature parameter, which needs to be a valid transaction signature for the current transaction. The current transaction details are unknown at the time of calling a contract function. This is why we have a separate `Sig` class made up of a keypair and hashtype, that represents a placeholder for these signatures. These placeholders are automatically replaced by the correct signature during the transaction building phase.
+Some cash contract functions require a signature parameter, which needs to be a valid transaction signature for the current transaction. The current transaction details are unknown at the time of calling a contract function. This is why we have a separate `Sig` class made up of a keypair and an optional hashtype, that represents a placeholder for these signatures. These placeholders are automatically replaced by the correct signature during the transaction building phase.
 
-**`new Sig(keypair: ECPair, hashtype: number)`**
+**`new Sig(keypair: ECPair, hashtype?: HashType)`**
 
 Creates a placeholder for a transaction signature of the current transaction. During the transaction building phase this placeholder is replaced by the actual signature.
 
 ```ts
-new Sig(keypair, 0x01)
+new Sig(keypair, HashType.SIGHASH_ALL)
 ```
 
 ### Transaction
@@ -134,7 +134,7 @@ Sends a transaction for an amount denoted in satoshis by argument `amount` to an
 
 ```ts
 const tx = await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .send(instance.address, 10000)
 ```
 
@@ -144,7 +144,7 @@ Sends a transaction with multiple outputs to multiple address-amount pairs speci
 
 ```ts
 const tx = await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .send([
     { to: instance.address, amount: 10000 },
     { to: instance.address, amount: 20000 },
@@ -155,7 +155,7 @@ These transactions can include outputs to other addresses as well as OP_RETURN o
 
 ```ts
 const tx = await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .send([
     { opReturn: ['0x6d02', 'Hello World!'] },
     { to: instance.address, amount: 10000 },
@@ -168,7 +168,7 @@ Prints the `meep` command that can be used to debug the transaction resulting fr
 
 ```ts
 await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .meep(instance.address, 10000)
 ```
 
@@ -178,7 +178,7 @@ Prints the `meep` command that can be used to debug the transaction resulting fr
 
 ```ts
 await instance.functions
-  .spend(pk, new Sig(keypair, 0x01))
+  .spend(pk, new Sig(keypair))
   .meep([
     { to: instance.address, amount: 10000 },
     { to: instance.address, amount: 20000 },

--- a/src/data/docs/cashscript/sdk.md
+++ b/src/data/docs/cashscript/sdk.md
@@ -12,23 +12,23 @@ The `Contract` class allows you to compile CashScript files into `Contract` obje
 
 Before instantiating a contract, first you need to create a new `Contract` object. This can be done by compiling a CashScript file, or by importing an Artifact file that was exported previously.
 
-**`Contract.fromCashFile(fn: string, network?: string): Contract`**
+**`Contract.compile(fnOrString: string, network?: string): Contract`**
 
-Compiles the CashScript file found at the path specified by argument `fn`. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
+If `fnOrString` is a file, compiles the CashScript file. If it is a source code string, it compiles the contract specified by the string. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
 
 ```ts
-const P2PKH: Contract = Contract.fromCashFile(
+const P2PKH: Contract = Contract.compile(
   path.join(__dirname, 'p2pkh.cash'),
   'testnet'
 )
 ```
 
-**`Contract.fromArtifact(fn: string, network?: string): Contract`**
+**`Contract.import(fnOrArtifact: string | Artifact, network?: string): Contract`**
 
-Imports an Artifact file that was compiled previously. This file is found at the path specified by argument `fn`. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
+Imports an Artifact that was compiled previously. If `fnOrArtifact` is a file, this imports the artifact JSON file. If it already is an Artifact object, this is used for the import directly. Optionally specify a network string (`'testnet'` or `'mainnet'`) to connect with. Returns a `Contract` object that can be further used to instantiate new instances of this contract.
 
 ```ts
-const P2PKH: Contract = Contract.fromArtifact(
+const P2PKH: Contract = Contract.import(
   path.join(__dirname, 'p2pkh.cash'),
   'testnet'
 )
@@ -38,9 +38,9 @@ const P2PKH: Contract = Contract.fromArtifact(
 
 A `Contract` object can be exported to an Artifact file to be imported at a later moment, so it can be stored or transfered more easily, and can be used without recompilation. If the object is exported after one or more new contracts have been instantiated, their details will be stored in the file as well so they can be easily accessed later on.
 
-**`contract.export(fn: string): void`**
+**`contract.export(fn?: string): Artifact`**
 
-Writes the contract's details to an Artifact file found at the location specified by argument `fn`, so it can be retrieved later. If the file does not exist yet, it is created. If the file already exists, **it is overwritten**.
+Writes the contract's details to an Artifact file found at the location specified by argument `fn` and returns the object, so it can be retrieved later. If the file does not exist yet, it is created. If the file already exists, **it is overwritten**. If no `fn` arguhment is passed, just the artifact object is returned.
 
 ```ts
 P2PKH.export(path.join(__dirname, 'p2pkh.json'))


### PR DESCRIPTION
- Add documentation for variable declaration
- Add documentation for comments
- Add documentation for global units
- Add note about NULLFAIL
- Add documentation for OP_RETURN outputs
- Add information about pragma directives
- Add documentation for bounded bytes types
- Update examples for optional hashtype in Sig
- Update documentation for Contract.compile, Contract.import, Contract.export
- Add documentation on covenants and output instantiation
- Add documentation on TxOptions