### PR TITLE
Add Wallet API Interactive Demos

### DIFF
--- a/src/data/docs/wallet-api/create-token.md
+++ b/src/data/docs/wallet-api/create-token.md
@@ -57,7 +57,7 @@ bitcoinWalletApi.createToken({
   symbol: 'WHT',
   decimals: 8,
   initialSupply: '1000000000',
-  tokenReceiverAddress: 'simpleledger:qq835u5srlcqwrtwt6xm4efwan30fxg9hcqag6fk03',
+  tokenReceiverAddress: 'simpleledger:qrw3pqgyjffxsv5qdj9n6zdpe70zqsegxcjyff6q8m',
 })
 .then((data: CreateTokenOutput) => {
   const {
@@ -83,6 +83,11 @@ bitcoinWalletApi.createToken({
   }
 });
 ```
+
+## Demo - Create new token
+
+<iframe height="625" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - createToken" src="https://codepen.io/nickfujita/embed/WNvOgGj?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
 
 ## Provider Request Handling
 

--- a/src/data/docs/wallet-api/get-address.md
+++ b/src/data/docs/wallet-api/get-address.md
@@ -75,6 +75,11 @@ bitcoinWalletApi.getAddress({
 });
 ```
 
+## Demo
+
+<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
+
 ## Provider Request Handling
 
 Depending on the account structure of the wallet, user handling may be different. In all cases, the wallet MUST return an address & protocol, or an error message. Each wallet may choose to provide back a default address in all cases, while others with multiple accounts and HD keys, may prompt a user to select an account from which to provide a new address.

--- a/src/data/docs/wallet-api/get-wallet-provider-status.md
+++ b/src/data/docs/wallet-api/get-wallet-provider-status.md
@@ -1,0 +1,55 @@
+---
+title: Get Wallet Status
+icon: wallet
+ordinal: 5
+---
+
+# getWalletProviderStatus
+
+Provides information about the availability of any wallet provider in the current browser environment. When called, the package will check of any of the following wallet providers are currently connected: Badger, Android, iOS.
+
+All providers will provided a status of either `AVAILABLE` or `NOT_AVAILABLE`, with the exception of Badger, which has a 3rd status `LOGGED_IN`.
+
+In the case of a `LOGGED_IN` for Badger, this means that your app is in an evironment where the Badger wallet is present, and it is ready for your app to interact with it. If Badger has a status of `AVAILABLE`, your app can not yet interact with it, so please inform the user to log into their Badger wallet if this status is received.
+
+Unlike other methods on the Wallet API, this is a synchronous method; directly returning the result.
+
+## Method Interface
+
+```
+function getWalletProviderStatus(): GetWalletProviderStatusOutput
+```
+
+## Input arguments
+
+N/A
+
+## Return value
+
+```
+interface GetWalletProviderStatusOutput {
+  badger: WalletProviderStatus;
+  android: WalletProviderStatus;
+  ios: WalletProviderStatus;
+}
+
+enum WalletProviderStatus {
+  NOT_AVAILABLE,
+  AVAILABLE,
+  LOGGED_IN,
+}
+```
+
+## Client Call Example
+
+```
+import bitcoinWalletApi from 'bitcoin-wallet-api';
+
+const providerStatuses = bitcoinWalletApi.getWalletProviderStatus();
+console.log('Provider statuses: ' + JSON.stringify(providerStatuses));
+```
+
+## Demo
+
+<iframe height="325" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAdgetWalletProviderStatus" src="https://codepen.io/nickfujita/embed/PoqjdRW?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>

--- a/src/data/docs/wallet-api/getting-started.md
+++ b/src/data/docs/wallet-api/getting-started.md
@@ -23,3 +23,8 @@ Install via npm [![npm version](https://badge.fury.io/js/bitcoin-wallet-api.svg)
 ### Testbed
 
 [Demo site](https://bitcoin-wallet-api-testbed.netlify.com/)
+
+The document for each method on this page, has a live demo of the wallet api embeded for you to try out the code. For example, here is a interactive example of how to get the user's address. Simply click on the button at the top of the render section on the right hand side. In this case the button is labeled as `getAddress`. Please ensure you have the [Badger browser extension wallet](https://badger.bitcoin.com/) installed in order to use this interactive demo on your desktop computer.
+
+<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>

--- a/src/data/docs/wallet-api/pay-invoice.md
+++ b/src/data/docs/wallet-api/pay-invoice.md
@@ -76,6 +76,16 @@ bitcoinWalletApi.payInvoice({
 });
 ```
 
+## Demo - Send BCH Invoice
+
+<iframe height="825" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - payInvoice - BCH" src="https://codepen.io/nickfujita/embed/ZEGyjZX?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
+
+## Demo - Send SLP Invoice
+
+<iframe height="950" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - payInvoice - SLP" src="https://codepen.io/nickfujita/embed/BaNZONK?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
+
 ## Provider Request Handling
 
 - Fetch payment request from merchant server

--- a/src/data/docs/wallet-api/send-assets.md
+++ b/src/data/docs/wallet-api/send-assets.md
@@ -81,6 +81,16 @@ bitcoinWalletApi.sendAssets({
 });
 ```
 
+## Demo - Send BCH
+
+<iframe height="575" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - sendAssets - BCH" src="https://codepen.io/nickfujita/embed/yLNgXqx?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
+
+## Demo - Send SLP Tokens
+
+<iframe height="600" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - sendAssets - SLP" src="https://codepen.io/nickfujita/embed/VwLPWVa?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+</iframe>
+
 ## Provider Request Handling
 
 - Validate the input parameters to make sure that the address provided is valid, and that it matches the provided protocol.


### PR DESCRIPTION
- Adds embedded interactive demos inline for each method
- Adds documentation for the `getWalletProviderStatus` method
- Small fix on `createToken` example

These changes will need to be merged in after the updates to the site:
https://github.com/bitcoin-portal/bitcoincom-developer/pull/50

These documents were [originally merged into master](https://github.com/Bitcoin-com/developer.bitcoin.com/pull/294). This PR merges master back into stage, and adds the updates listed above.