### PR TITLE
Update bitcoin-wallet-api to bitcoincom-link

### DIFF
--- a/src/data/docs/bitcoincom-link/create-token.md
+++ b/src/data/docs/bitcoincom-link/create-token.md
@@ -50,9 +50,9 @@ interface Error {
 ## Example
 
 ```
-import bitcoinWalletApi from 'bitcoin-wallet-api';
+import bitcoincomLink from 'bitcoincom-link';
 
-bitcoinWalletApi.createToken({
+bitcoincomLink.createToken({
   name: 'World Hunger Token',
   symbol: 'WHT',
   decimals: 8,
@@ -86,7 +86,7 @@ bitcoinWalletApi.createToken({
 
 ## Demo - Create new token
 
-<iframe height="625" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - createToken" src="https://codepen.io/nickfujita/embed/WNvOgGj?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="625" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - createToken" src="https://codepen.io/nickfujita/embed/WNvOgGj?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Provider Request Handling

--- a/src/data/docs/bitcoincom-link/get-address.md
+++ b/src/data/docs/bitcoincom-link/get-address.md
@@ -46,9 +46,9 @@ interface Error {
 ## Client Call Example
 
 ```
-import bitcoinWalletApi from 'bitcoin-wallet-api';
+import bitcoincomLink from 'bitcoincom-link';
 
-bitcoinWalletApi.getAddress({
+bitcoincomLink.getAddress({
   protocol: 'BCH',
 })
 .then((data: GetAccountOutput) => {
@@ -77,7 +77,7 @@ bitcoinWalletApi.getAddress({
 
 ## Demo
 
-<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Provider Request Handling

--- a/src/data/docs/bitcoincom-link/get-wallet-provider-status.md
+++ b/src/data/docs/bitcoincom-link/get-wallet-provider-status.md
@@ -43,13 +43,13 @@ enum WalletProviderStatus {
 ## Client Call Example
 
 ```
-import bitcoinWalletApi from 'bitcoin-wallet-api';
+import bitcoincomLink from 'bitcoincom-link';
 
-const providerStatuses = bitcoinWalletApi.getWalletProviderStatus();
+const providerStatuses = bitcoincomLink.getWalletProviderStatus();
 console.log('Provider statuses: ' + JSON.stringify(providerStatuses));
 ```
 
 ## Demo
 
-<iframe height="325" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAdgetWalletProviderStatus" src="https://codepen.io/nickfujita/embed/PoqjdRW?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="325" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - getAdgetWalletProviderStatus" src="https://codepen.io/nickfujita/embed/PoqjdRW?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>

--- a/src/data/docs/bitcoincom-link/getting-started.md
+++ b/src/data/docs/bitcoincom-link/getting-started.md
@@ -16,15 +16,15 @@ The method interface will allow any web based application to interact with the B
 
 ### Installation
 
-In a browser - cdn [![](https://data.jsdelivr.com/v1/package/npm/bitcoin-wallet-api/badge)](https://www.jsdelivr.com/package/npm/bitcoin-wallet-api)
+In a browser - cdn [![](https://data.jsdelivr.com/v1/package/npm/bitcoincom-link/badge)](https://www.jsdelivr.com/package/npm/bitcoincom-link)
 
-Install via npm [![npm version](https://badge.fury.io/js/bitcoin-wallet-api.svg)](https://badge.fury.io/js/bitcoin-wallet-api)
+Install via npm [![npm version](https://badge.fury.io/js/bitcoincom-link.svg)](https://badge.fury.io/js/bitcoincom-link)
 
 ### Testbed
 
-[Demo site](https://bitcoin-wallet-api-testbed.netlify.com/)
+[Demo site](https://bitcoincom-link-testbed.netlify.com/)
 
 The document for each method on this page, has a live demo of the wallet api embeded for you to try out the code. For example, here is a interactive example of how to get the user's address. Simply click on the button at the top of the render section on the right hand side. In this case the button is labeled as `getAddress`. Please ensure you have the [Badger browser extension wallet](https://badger.bitcoin.com/) installed in order to use this interactive demo on your desktop computer.
 
-<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="475" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - getAddress" src="https://codepen.io/nicolasfujita/embed/xxGgrZm?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>

--- a/src/data/docs/bitcoincom-link/getting-started.md
+++ b/src/data/docs/bitcoincom-link/getting-started.md
@@ -4,7 +4,7 @@ icon: home
 ordinal: 0
 ---
 
-### Wallet API
+### Bitcoin.com Link
 
 A standard interface for blockchain connected applications to interact with 3rd party user wallets.
 

--- a/src/data/docs/bitcoincom-link/pay-invoice.md
+++ b/src/data/docs/bitcoincom-link/pay-invoice.md
@@ -43,9 +43,9 @@ interface Error {
 ## Example
 
 ```
-import bitcoinWalletApi from 'bitcoin-wallet-api';
+import bitcoincomLink from 'bitcoincom-link';
 
-bitcoinWalletApi.payInvoice({
+bitcoincomLink.payInvoice({
   url: 'bitcoincash:?r=https://bitpay.com/i/LHQmUTjzAcqX1NU47Nk1mJ',
 })
 .then((data: PayInvoiceOutput) => {
@@ -78,12 +78,12 @@ bitcoinWalletApi.payInvoice({
 
 ## Demo - Send BCH Invoice
 
-<iframe height="825" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - payInvoice - BCH" src="https://codepen.io/nickfujita/embed/ZEGyjZX?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="825" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - payInvoice - BCH" src="https://codepen.io/nickfujita/embed/ZEGyjZX?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Demo - Send SLP Invoice
 
-<iframe height="950" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - payInvoice - SLP" src="https://codepen.io/nickfujita/embed/BaNZONK?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="950" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - payInvoice - SLP" src="https://codepen.io/nickfujita/embed/BaNZONK?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Provider Request Handling

--- a/src/data/docs/bitcoincom-link/send-assets.md
+++ b/src/data/docs/bitcoincom-link/send-assets.md
@@ -46,9 +46,9 @@ interface Error {
 ## Example
 
 ```
-import bitcoinWalletApi from 'bitcoin-wallet-api';
+import bitcoincomLink from 'bitcoincom-link';
 
-bitcoinWalletApi.sendAssets({
+bitcoincomLink.sendAssets({
   to: 'bitcoincash:qrd9khmeg4nqag3h5gzu8vjt537pm7le85lcauzezc',
   protocol: 'BCH',
   value: '0.000123',
@@ -83,12 +83,12 @@ bitcoinWalletApi.sendAssets({
 
 ## Demo - Send BCH
 
-<iframe height="575" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - sendAssets - BCH" src="https://codepen.io/nickfujita/embed/yLNgXqx?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="575" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - sendAssets - BCH" src="https://codepen.io/nickfujita/embed/yLNgXqx?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Demo - Send SLP Tokens
 
-<iframe height="600" style="width: 100%;" scrolling="no" title="Bitcoin Wallet API - sendAssets - SLP" src="https://codepen.io/nickfujita/embed/VwLPWVa?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
+<iframe height="600" style="width: 100%;" scrolling="no" title="Bitcoin.com Link - sendAssets - SLP" src="https://codepen.io/nickfujita/embed/VwLPWVa?height=265&theme-id=dark&default-tab=js,result" frameborder="no" allowtransparency="true" allowfullscreen="true">
 </iframe>
 
 ## Provider Request Handling


### PR DESCRIPTION
The name of the wallet api service has been updated to Bitcoin.com Link. These changes update the documentation to the new name, with new links.

Update to site can be found here:
https://github.com/bitcoin-portal/bitcoincom-developer/pull/54